### PR TITLE
replace problematic <> with curly braces

### DIFF
--- a/lib/markdownToHtml.ts
+++ b/lib/markdownToHtml.ts
@@ -56,3 +56,16 @@ export const updateMarkdownImagePaths = (markdownString: string, imagesRuntimePa
   const result = markdownString.replace(regex, replaceFunc);
   return result;
 }
+
+export const updateMarkdownHtmlStyleTags = (markdownString: string) => {
+  const regex = /"([^"]*)"/g;
+
+  function replaceFunc(match: string, content: string) {
+      const replacedContent = content.replace(/</g, '{{').replace(/>/g, '}}');
+      return `"${replacedContent}"`;
+  }
+
+  const result = markdownString.replace(regex, replaceFunc);
+
+  return result;
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -2,7 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import matter from 'gray-matter'
 import { MERMAID_SNIPPET, mdToHtml } from './customMarked'
-import { insertIdsToHeaders, updateMarkdownImagePaths } from './markdownToHtml'
+import { insertIdsToHeaders, updateMarkdownHtmlStyleTags, updateMarkdownImagePaths } from './markdownToHtml'
 import { MarkdownFileMetadata, VersionDocType } from '@/types/types'
 
 export function slugify(input: string): string {
@@ -41,6 +41,7 @@ export const readMarkdownFile = async function(filePath: string, imagesPath: str
   const fullPath = path.normalize(path.join(process.cwd(), filePath));
   let markdown = fs.readFileSync(fullPath, 'utf8');
   markdown = updateMarkdownImagePaths(markdown, imagesPath);
+  markdown = updateMarkdownHtmlStyleTags(markdown);
   return markdown;
 };
 
@@ -55,7 +56,7 @@ export const readAndConcatMarkdownFiles = async function(parentItem: MarkdownFil
   });
 
   markdownAll = updateMarkdownImagePaths(markdownAll, imagesPath);
-
+  markdownAll = updateMarkdownHtmlStyleTags(markdownAll);
   const compiled = compileMarkdownToHTML(markdownAll, parentItem.ordinal);
   // inject script to make mermaid js work its magic
   if (compiled.html.includes(MERMAID_SNIPPET)) {


### PR DESCRIPTION
real html-tags, like <style> were causing issues in rendering. Replaced those with curly braces inside json snippets
 e.g "style":"<style ...>" -> "style":"{{ style }}" 
![image](https://github.com/oskariorg/oskari-documentation-site/assets/131667037/d37731d9-20a8-4a21-9d43-6c260be7b27f)
