### PR TITLE
fix bug in resetting running number

### DIFF
--- a/lib/markdownToHtml.ts
+++ b/lib/markdownToHtml.ts
@@ -22,11 +22,19 @@ export const insertIdsToHeaders = (htmlString: string, startingSectionNumber: st
   const headerRegex = /<h([1-3])>(.*?)<\/h\1>/g
   const anchorLinks: Array<DocAnchorLinksType> = []
   const sectionCounter = [parseInt(startingSectionNumber) - 1, 0, 0, 0, 0, 0];
+  let previousLevel = parseInt(startingSectionNumber) - 1;
 
   const newHtmlString = htmlString.replace(
     headerRegex,
     function (match: string, level: string, content: string) {
-      sectionCounter[parseInt(level) - 1]++;
+      const intLevel = parseInt(level);
+      sectionCounter[intLevel - 1]++;
+      if (intLevel < previousLevel) {
+        for (let i = intLevel; i < sectionCounter.length; i++) {
+          sectionCounter[i] = 0;
+        }
+      }
+      previousLevel = intLevel;
       const slug = slugify(content)
       const sectionNumber = sectionCounter.slice(0, parseInt(level)).join('.');
       anchorLinks.push({ level, content, slug, sectionNumber });


### PR DESCRIPTION
Reset the sublevel counter when higher level number changes so we start the next level at 1 instead of the number that was running (i.e. we get 3.1.1 instead of , say, 3.1.29 as the first third level heading under section 3.1)