### PR TITLE
Api doc UI

### DIFF
--- a/app/resources/api/components/ApiDocChangeLog.tsx
+++ b/app/resources/api/components/ApiDocChangeLog.tsx
@@ -1,12 +1,9 @@
 import { getMarkdownContentAsHtml } from '@/lib/utils';
 import React from 'react';
+import ApiDocContentWrapper from './ApiDocContentWrapper';
 
 export default async function ApiDocChangeLog({ version }: { version: string }) {
   const filePath = `_content/api/versions/${version}/CHANGELOG.md`;
   const html = await getMarkdownContentAsHtml(filePath, '');
-  return <>
-    <article>
-      <div style={{ wordWrap: 'break-word'}}dangerouslySetInnerHTML={{ __html: html }}></div>
-    </article>
-  </>
+  return <ApiDocContentWrapper html={html}/>;
 }

--- a/app/resources/api/components/ApiDocContentWrapper.tsx
+++ b/app/resources/api/components/ApiDocContentWrapper.tsx
@@ -1,0 +1,7 @@
+import '@/styles/apidoc.scss'
+
+export default function ApiDocContentWrapper({html}: {html: string}) {
+  return <article>
+    <div className={'apidocContentWrapper'} dangerouslySetInnerHTML={{ __html: html }}/>
+  </article>;
+}

--- a/app/resources/api/components/ApiSectionContentPage.tsx
+++ b/app/resources/api/components/ApiSectionContentPage.tsx
@@ -30,7 +30,7 @@ export default function ApiSectionContentPage({
         <VersionSidebar selectedVersion={version} versions={versions} baseHref={baseHref} />
         {sideBarContent}
     </div>
-    <div style={{overflow: 'hidden', wordWrap:'break-word'}}>
+    <div>
         {mainContent}
     </div>
   </Layout>;

--- a/app/resources/api/components/BundlesSidebarContent.tsx
+++ b/app/resources/api/components/BundlesSidebarContent.tsx
@@ -13,8 +13,8 @@ export default function BundlesSidebarContent(
     baseHref: string
   }) {
 
-    return <div style={{marginTop: '2em'}}>
-      <h3 style={{ fontSize: '1.125rem'}}>Select bundle</h3>
+    return <div  className='sidebarMainDiv'>
+      <h3 className='sidebarCheckboxesTitle'>Select bundle</h3>
       <AccordionGroup>
         {elements?.map((element: Bundle) => {
           return <Accordion

--- a/app/resources/api/components/EventsAndRequestsSidebarContent.tsx
+++ b/app/resources/api/components/EventsAndRequestsSidebarContent.tsx
@@ -5,6 +5,8 @@ import Accordion from '@/components/Accordion/Accordion';
 import SidebarAccordionContent from './SideBarAccordionContent';
 import Checkbox, { CheckboxGroup } from '@/components/Checkbox/Checkbox';
 import { useState } from 'react';
+import '@/styles/apidoc.scss';
+
 export default function EventsAndRequestsSidebarContent(
 {
   elements,
@@ -29,8 +31,8 @@ export default function EventsAndRequestsSidebarContent(
     setShowDescription(checked);
   }
 
-  return <div style={{marginTop: '2em'}}>
-    <h3 style={{ fontSize: '1.125rem'}}>{title}</h3>
+  return <div className='sidebarMainDiv'>
+    <h3 className='sidebarCheckboxesTitle'>{title}</h3>
     <CheckboxGroup>
       <Checkbox title='Description' isChecked={showDescription} onChange={showDescriptionCheckedChanged}/>
       <Checkbox title='RPC only' isChecked={rpcOnly} onChange={checkedChanged}/>

--- a/app/resources/api/components/HtmlContentPage.tsx
+++ b/app/resources/api/components/HtmlContentPage.tsx
@@ -1,10 +1,7 @@
 import { getMarkdownContentAsHtml } from '@/lib/utils';
+import ApiDocContentWrapper from './ApiDocContentWrapper';
 
 export default async function HtmlContentPage({ mdPath, imagesPath }: { mdPath: string, imagesPath: string }) {
   const html = await getMarkdownContentAsHtml(mdPath, imagesPath);
-  return <>
-    <article>
-      <div style={{ wordWrap: 'break-word'}}dangerouslySetInnerHTML={{ __html: html }}></div>
-    </article>
-  </>
+  return <ApiDocContentWrapper html={html}/>
 }

--- a/app/resources/api/components/SideBarAccordionContent.tsx
+++ b/app/resources/api/components/SideBarAccordionContent.tsx
@@ -2,7 +2,7 @@ import slugify from 'slugify';
 import { SidebarAccordionItem } from '@/types/api';
 import Link from 'next/link';
 import styles from '@/styles/accordion.module.scss'
-
+import '@/styles/apidoc.scss';
 export default function SidebarAccordionContent(
   {
     elements,
@@ -21,11 +21,11 @@ export default function SidebarAccordionContent(
           return <li key={slug + '_' + index}>
             <Link
               href={baseHref + slug}
-              style={{ paddingBottom: '0.5rem', color: '#428bca', fontSize: '1rem'}}
+              className='apidocSidebarLink'
             >
               {item.name}
             </Link>
-            { showDescription && <div style={{ padding: '0 2rem', fontSize: '0.9rem', overflow: 'hidden', wordWrap: 'break-word' }}>{item.desc}</div>}
+            { showDescription && <div className={'apidocSidebarDesc'}>{item.desc}</div>}
           </li>
         })}
       </ul>

--- a/lib/markdownToHtml.ts
+++ b/lib/markdownToHtml.ts
@@ -47,7 +47,7 @@ export const insertIdsToHeaders = (htmlString: string, startingSectionNumber: st
   }
 }
 
-export const updateMarkdownImagePaths = (markdownString: string, imagesRuntimePath: string = '') => {
+export const updateMarkdownImagePaths = (markdownString: string, imagesRuntimePath: string = ''): string => {
   const regex = /!\[(.*?)\]\((.*?)\)/g;
 
   function replaceFunc(match: string, altText: string, imagePath: string) {
@@ -65,7 +65,7 @@ export const updateMarkdownImagePaths = (markdownString: string, imagesRuntimePa
   return result;
 }
 
-export const updateMarkdownHtmlStyleTags = (markdownString: string) => {
+export const updateMarkdownHtmlStyleTags = (markdownString: string): string => {
   const regex = /"([^"]*)"/g;
 
   function replaceFunc(match: string, content: string) {
@@ -76,4 +76,34 @@ export const updateMarkdownHtmlStyleTags = (markdownString: string) => {
   const result = markdownString.replace(regex, replaceFunc);
 
   return result;
+}
+
+export const processHeaders = (markdownContent:string): string => {
+  const headerRegex = /^(#+)\s+(.*?)\s*$/gm;
+  const tagRegex = /\[(.*?)\]/g;
+
+  const processedContent = markdownContent.replace(headerRegex, (match, hashes, title) => {
+      const tags = title.match(tagRegex);
+      let cleanTitle = title.replace(tagRegex, '');
+
+      if (tags) {
+          const tagClasses = tags.map((tag: string) => tag.replace(/\[|\]/g, '').trim()).join(' ');
+          cleanTitle = `<h${hashes.length} class="${tagClasses}">${cleanTitle}</h${hashes.length}>`;
+      } else {
+          cleanTitle = `<h${hashes.length}>${cleanTitle}</h${hashes.length}>`;
+      }
+
+      return cleanTitle;
+  });
+
+  return processedContent;
+}
+
+export const processCodeBlocks = (markdownContent: string): string => {
+  const codeRegex = /`(.*?)`/g;
+  const contentWithCodeBlocks = markdownContent.replace(codeRegex, (match, codeContent) => {
+      return `<code>${codeContent}</code>`;
+  });
+
+  return contentWithCodeBlocks;
 }

--- a/styles/apidoc.scss
+++ b/styles/apidoc.scss
@@ -1,0 +1,30 @@
+div.apidocContentWrapper {
+  word-wrap: 'break-word';
+
+  /*change headings*/
+  .add {
+    color : green;
+  }
+
+  & .mod {
+    color : orange;
+  }
+
+  .rem {
+    color : red;
+  }
+
+  .breaking {
+    background-color : red;
+  }
+
+  code {
+    padding: 2px 4px;
+    font-size: 90%;
+    color: #c7254e;
+    background-color: #f9f2f4;
+    white-space: nowrap;
+    border-radius: 4px;
+  }
+}
+

--- a/styles/apidoc.scss
+++ b/styles/apidoc.scss
@@ -28,3 +28,15 @@ div.apidocContentWrapper {
   }
 }
 
+.apidocSidebarLink {
+  padding-bottom: 0.5rem;
+  color: #428bca;
+  font-size: 1rem;
+}
+
+.apidocSidebarDesc {
+  padding: 0 2rem;
+  font-size: 0.9rem;
+  overflow: hidden;
+  word-wrap: break-word;
+}

--- a/styles/apidoc.scss
+++ b/styles/apidoc.scss
@@ -40,3 +40,11 @@ div.apidocContentWrapper {
   overflow: hidden;
   word-wrap: break-word;
 }
+
+.sidebarMainDiv {
+  top: 2em;
+}
+
+.sidebarCheckboxesTitle {
+  font-size: 1.125rem;
+}


### PR DESCRIPTION
-Add some css-classes to headers and codeblocks when rendering html + styling for these (affects changelog). Not yet ready, breaking changes & rpc (etc.) badges stille need to be implemented. Especially breaking changes now look kinda wild.

![image](https://github.com/oskariorg/oskari-documentation-site/assets/131667037/25624c4f-622d-47a1-a44a-6c7e91f23dfb)



