### PR TITLE
Latest doc

### DIFF
--- a/app/resources/docs/[version]/page.tsx
+++ b/app/resources/docs/[version]/page.tsx
@@ -1,57 +1,10 @@
-import DocumentCard from '@/components/Cards/DocumentCard'
-import VersionSidebar from '@/components/VersionSidebar'
 import { getVersionIndex } from '@/lib/utils'
-import Link from 'next/link'
-import { compareSemanticVersions } from '@/utils/misc'
-
-import availableVersions from '@/_content/docs';
-import { MarkdownFileMetadata, VersionedResourceLink } from '@/types/types'
-export const generateMetadata = ({
-  params,
-}: {
-  params: { slug: string; version: string }
-}) => {
-  return { title: params.version || 'Documentation' }
-}
-
+import { redirect } from 'next/navigation'
 export default async function VersionPage({
   params,
 }: {
   params: { version: string }
 }) {
-
-  const versions = [
-    ...new Set(
-      availableVersions
-        .sort((a, b) => compareSemanticVersions(a, b))
-        .reverse() || []
-    ),
-  ]
-
   const indexJSON = await getVersionIndex(params.version);
-  const titles = indexJSON?.map((item: MarkdownFileMetadata) => {
-    return { title: item.title, url: params.version + '/' + item.slug, slug: item.slug };
-  }) || [];
-
-  return (
-    <>
-      <div style={{ display: 'flex', flexDirection: 'column', gap: '2rem' }}>
-        <VersionSidebar selectedVersion={params.version} versions={versions} baseHref='/resources/docs/'/>
-      </div>
-      <div
-        style={{
-          display: 'grid',
-          gridTemplateColumns: 'repeat(auto-fill, minmax(250px, 1fr))',
-          gap: '2rem',
-          marginTop: 27,
-        }}
-      >
-        {titles?.map((item: VersionedResourceLink) => (
-          <Link href={`/resources/docs/${item.url}`} key={item.slug}>
-            <DocumentCard title={item.title || ''} />
-          </Link>
-        ))}
-      </div>
-    </>
-  )
+  redirect('/resources/docs/' + params.version + '/' + indexJSON[0].slug);
 }

--- a/app/resources/docs/page.tsx
+++ b/app/resources/docs/page.tsx
@@ -1,51 +1,6 @@
-import availableVersions from '@/_content/docs';
-import VersionSidebar from '@/components/VersionSidebar'
-import { compareSemanticVersions } from '@/utils/misc'
-import { Metadata } from 'next'
-
-export const metadata: Metadata = {
-  title: 'Documentation',
-}
-
-export default function DocsPage() {
-  const versions = [
-    ...new Set(
-      availableVersions
-        .sort((a, b) => compareSemanticVersions(a, b))
-        .reverse()
-    ),
-  ]
-  return (
-    <>
-      <VersionSidebar selectedVersion='' versions={versions}  baseHref='/resources/docs/'/>
-      <article>
-        <h1>Docs Content</h1>
-        <p>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla aliquam
-          urna a dui porta, at interdum diam tempor. Maecenas ultricies
-          facilisis odio eget viverra. Integer suscipit efficitur felis vel
-          malesuada. Cras sed lacinia velit. Quisque vel euismod diam. Cras non
-          ante nec mi euismod aliquet at sit amet nisi. Mauris dolor metus,
-          aliquam eget sagittis ac, venenatis vel urna. Orci varius natoque
-          penatibus et magnis dis parturient montes, nascetur ridiculus mus.
-          Nulla elit eros, posuere vitae pulvinar eget, laoreet non risus. Ut ut
-          erat non lectus porta auctor id a mauris. Phasellus a diam arcu. Nulla
-          facilisi. Phasellus pharetra augue nibh, tincidunt pretium risus
-          placerat ac. Duis in luctus lorem.
-        </p>
-        <p>
-          Phasellus convallis porta velit, id dignissim arcu consectetur mattis.
-          Nam tincidunt, ipsum viverra tempor lacinia, neque quam mollis tellus,
-          a hendrerit orci odio sed tellus. Nullam vulputate, magna varius
-          tempus mattis, ligula ante imperdiet quam, vel lacinia ante libero et
-          nibh. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Phasellus augue dui, euismod id massa a, vestibulum hendrerit tortor.
-          Curabitur sed nibh dapibus, sodales mauris at, fermentum tellus. Sed
-          nec turpis erat. Duis ipsum diam, venenatis et nunc nec, finibus
-          tincidunt nunc. Curabitur molestie auctor consequat. Morbi vel felis
-          nunc.
-        </p>
-      </article>
-    </>
-  )
+import { getVersionIndex } from '@/lib/utils'
+import { redirect } from 'next/navigation'
+export default async function DocsMainPage() {
+  const indexJSON = await getVersionIndex('latest');
+  redirect('/resources/docs/latest/' + indexJSON[0].slug);
 }

--- a/scripts/runAll.js
+++ b/scripts/runAll.js
@@ -1,10 +1,12 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const { exec } = require('child_process');
-
-exec('node scripts/generateDocs.js ' + process.argv.slice(2)[0]);
-exec('node scripts/generateContentMetadata.js');
-exec('node scripts/generateDocumentationMetadata.js');
+const { execSync } = require('child_process');
 
 // always regenerate 'latest'
-exec('node scripts/generateApidocs.js latest');
-exec('node scripts/generateApidocs.js ' + process.argv.slice(2)[0]);
+execSync('node scripts/generateDocs.js latest');
+execSync('node scripts/generateDocs.js ' + process.argv.slice(2)[0]);
+execSync('node scripts/generateContentMetadata.js');
+execSync('node scripts/generateDocumentationMetadata.js');
+
+// always regenerate 'latest'
+execSync('node scripts/generateApidocs.js latest');
+execSync('node scripts/generateApidocs.js ' + process.argv.slice(2)[0]);


### PR DESCRIPTION
-generate 'latest' - version always when building
-change exec to execSync -> plain exec was sometimes causing issues where generating metadata for instance would fail because some other exec was still pending.
-remove the lorem ipsumous in-between pages in docs and redirect straight to latest versions docs first chapter.