### PR TITLE
fix content wrapping in apidoc

### DIFF
--- a/app/resources/api/components/ApiSectionContentPage.tsx
+++ b/app/resources/api/components/ApiSectionContentPage.tsx
@@ -30,7 +30,7 @@ export default function ApiSectionContentPage({
         <VersionSidebar selectedVersion={version} versions={versions} baseHref={baseHref} />
         {sideBarContent}
     </div>
-    <div>
+    <div className={'overFlowHidden'}>
         {mainContent}
     </div>
   </Layout>;

--- a/styles/apidoc.scss
+++ b/styles/apidoc.scss
@@ -1,3 +1,7 @@
+div.overFlowHidden {
+  overflow: hidden;
+}
+
 div.apidocContentWrapper {
   overflow: hidden;
   word-wrap: break-word;


### PR DESCRIPTION
bring back hidden overflow to wrapping div to fix wrapping (apidoc content)