### PR TITLE
Generation script refactor

### DIFF
--- a/components/VersionSidebar.tsx
+++ b/components/VersionSidebar.tsx
@@ -21,7 +21,7 @@ export default async function VersionSidebar({
   baseHref: string
 }) {
   const versionsWithoutSelected =
-    versions?.filter((version) => selectedVersion !== version) || []
+    versions?.filter((version) => selectedVersion !== version && version !== 'unreleased') || []
 
   const renderVersionMenuContent = (items: string[]) => (
     <ul className={styles.accordionMenu}>

--- a/scripts/documentationMetadataHelper.js
+++ b/scripts/documentationMetadataHelper.js
@@ -1,0 +1,23 @@
+/*eslint @typescript-eslint/no-var-requires: 0*/
+const fs = require('fs');
+const path = require('path');
+
+function getSubdirectories(rootDir) {
+  return fs.readdirSync(rootDir, { withFileTypes: true })
+      .filter(dirent => dirent.isDirectory())
+      .map(dirent => dirent.name);
+}
+
+function generateDocumentationMetadata(fullPath) {
+  const subdirectories = getSubdirectories(fullPath);
+  // filter out version 'unreleased' so it will not show up in menus etc. but is still accessible for testing purposes
+  const sortedVersions = subdirectories
+      .filter((version) => version !== 'unreleased')
+      .sort((a, b) => parseFloat(a) - parseFloat(b));
+
+  const indexContent = `const availableVersions = ${JSON.stringify(sortedVersions)};\n\nexport default availableVersions;`;
+  fs.writeFileSync(path.join(fullPath, 'index.js'), indexContent);
+}
+
+exports.getSubdirectories = getSubdirectories;
+exports.generateDocumentationMetadata = generateDocumentationMetadata;

--- a/scripts/generateApidocs.js
+++ b/scripts/generateApidocs.js
@@ -1,6 +1,7 @@
 /*eslint @typescript-eslint/no-var-requires: 0*/
 const fs = require('fs');
 const path = require('path');
+const { generateDocumentationMetadata, getSubdirectories } = require('./documentationMetadataHelper');
 
 function copyContent(source, destination) {
   if (!fs.existsSync(source)) {
@@ -55,13 +56,6 @@ function hasTag(fileContent, tag) {
       return false;
   }
 }
-
-function getSubdirectories(rootDir) {
-  return fs.readdirSync(rootDir, { withFileTypes: true })
-      .filter(dirent => dirent.isDirectory())
-      .map(dirent => dirent.name);
-}
-
 
 function generateRequestsOrEvents(fullPath, moduleName, bundleName, type) {
   // type = request | event
@@ -162,17 +156,6 @@ function syncResourcesByVersion(sourcePath, destinationPath) {
   for (const version of subdirectories) {
     copyImagesRecursively(sourcePath + version, destinationPath + version);
   }
-}
-
-function generateDocumentationMetadata(fullPath) {
-  const subdirectories = getSubdirectories(fullPath);
-  // filter out version 'unreleased' so it will not show up in menus etc. but is still accessible for testing purposes
-  const sortedVersions = subdirectories
-    .filter((version) => version !== 'unreleased')
-    .sort((a, b) => parseFloat(a) - parseFloat(b));
-
-  const indexContent = `const availableVersions = ${JSON.stringify(sortedVersions)};\n\nexport default availableVersions;`;
-  fs.writeFileSync(path.join(fullPath, 'index.js'), indexContent);
 }
 
 /** API docs metadata generation */

--- a/scripts/generateApidocs.js
+++ b/scripts/generateApidocs.js
@@ -166,7 +166,11 @@ function syncResourcesByVersion(sourcePath, destinationPath) {
 
 function generateDocumentationMetadata(fullPath) {
   const subdirectories = getSubdirectories(fullPath);
-  const sortedVersions = subdirectories.sort((a, b) => parseFloat(a) - parseFloat(b));
+  // filter out version 'unreleased' so it will not show up in menus etc. but is still accessible for testing purposes
+  const sortedVersions = subdirectories
+    .filter((version) => version !== 'unreleased')
+    .sort((a, b) => parseFloat(a) - parseFloat(b));
+
   const indexContent = `const availableVersions = ${JSON.stringify(sortedVersions)};\n\nexport default availableVersions;`;
   fs.writeFileSync(path.join(fullPath, 'index.js'), indexContent);
 }

--- a/scripts/generateDocumentationMetadata.js
+++ b/scripts/generateDocumentationMetadata.js
@@ -97,7 +97,11 @@ function syncResourcesByVersion(resourcesCopyPath, resourcesRuntimePath) {
 
 function generateDocumentationMetadata(fullPath) {
     const subdirectories = getSubdirectories(fullPath);
-    const sortedVersions = subdirectories.sort((a, b) => parseFloat(a) - parseFloat(b));
+    // filter out version 'unreleased' so it will not show up in menus etc. but is still accessible for testing purposes
+    const sortedVersions = subdirectories
+        .filter((version) => version !== 'unreleased')
+        .sort((a, b) => parseFloat(a) - parseFloat(b));
+
     const indexContent = `const availableVersions = ${JSON.stringify(sortedVersions)};\n\nexport default availableVersions;`;
     fs.writeFileSync(path.join(fullPath, 'index.js'), indexContent);
 }

--- a/scripts/generateDocumentationMetadata.js
+++ b/scripts/generateDocumentationMetadata.js
@@ -4,12 +4,7 @@ const path = require('path');
 const grayMatter = require('gray-matter');
 const slugify = require('slugify');
 const syncResources = require('./syncResourcesFolder');
-
-function getSubdirectories(rootDir) {
-    return fs.readdirSync(rootDir, { withFileTypes: true })
-        .filter(dirent => dirent.isDirectory())
-        .map(dirent => dirent.name);
-}
+const { generateDocumentationMetadata, getSubdirectories } = require('./documentationMetadataHelper');
 
 function getFrontmatter(filePath) {
     const fileContent = fs.readFileSync(filePath, 'utf8');
@@ -93,17 +88,6 @@ function syncResourcesByVersion(resourcesCopyPath, resourcesRuntimePath) {
     for (const version of subdirectories) {
         syncResources(resourcesCopyPath + version, resourcesRuntimePath + version);
     }
-}
-
-function generateDocumentationMetadata(fullPath) {
-    const subdirectories = getSubdirectories(fullPath);
-    // filter out version 'unreleased' so it will not show up in menus etc. but is still accessible for testing purposes
-    const sortedVersions = subdirectories
-        .filter((version) => version !== 'unreleased')
-        .sort((a, b) => parseFloat(a) - parseFloat(b));
-
-    const indexContent = `const availableVersions = ${JSON.stringify(sortedVersions)};\n\nexport default availableVersions;`;
-    fs.writeFileSync(path.join(fullPath, 'index.js'), indexContent);
 }
 
 const docsRelativeDir = './_content/docs/';


### PR DESCRIPTION
-enable building a test version not selectable/visible in ui using the magicword 'unreleased' as version number when building
-some refactoring (common bits to helper)