### PR TITLE
Default api docs to unreleased

### DIFF
--- a/components/VersionSidebar.tsx
+++ b/components/VersionSidebar.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import styles from '@/styles/accordion.module.scss'
 import Accordion from './Accordion/Accordion'
+import { UNRELEASED_VERSION } from '../utils/constants'
 
 type subtitleLinks = {
   slug: string
@@ -21,7 +22,7 @@ export default async function VersionSidebar({
   baseHref: string
 }) {
   const versionsWithoutSelected =
-    versions?.filter((version) => selectedVersion !== version && version !== 'unreleased') || []
+    versions?.filter((version) => selectedVersion !== version && version !== UNRELEASED_VERSION) || []
 
   const renderVersionMenuContent = (items: string[]) => (
     <ul className={styles.accordionMenu}>

--- a/scripts/documentationMetadataHelper.js
+++ b/scripts/documentationMetadataHelper.js
@@ -1,6 +1,7 @@
 /*eslint @typescript-eslint/no-var-requires: 0*/
 const fs = require('fs');
 const path = require('path');
+const UNRELEASED_VERSION = 'unreleased';
 
 function getSubdirectories(rootDir) {
   return fs.readdirSync(rootDir, { withFileTypes: true })
@@ -12,7 +13,7 @@ function generateDocumentationMetadata(fullPath) {
   const subdirectories = getSubdirectories(fullPath);
   // filter out version 'unreleased' so it will not show up in menus etc. but is still accessible for testing purposes
   const sortedVersions = subdirectories
-      .filter((version) => version !== 'unreleased')
+      .filter((version) => version !== UNRELEASED_VERSION)
       .sort((a, b) => parseFloat(a) - parseFloat(b));
 
   const indexContent = `const availableVersions = ${JSON.stringify(sortedVersions)};\n\nexport default availableVersions;`;

--- a/scripts/generateApidocs.js
+++ b/scripts/generateApidocs.js
@@ -164,6 +164,12 @@ const version = process.argv.slice(2)[0] || 'latest';
 
 /** Copy the content from under oskari-frontend */
 const apidocsFullpath = './_content/api/versions/';
+const relativeUrlToContent = path.normalize(path.join(process.cwd(), apidocsFullpath));
+if (!fs.existsSync(relativeUrlToContent)) {
+  // create base dir if not available
+  fs.mkdirSync(relativeUrlToContent, { recursive: true });
+}
+
 const sourceDirectoryRelative = '../oskari-frontend/api';
 const destinationDirectoryRelative = apidocsFullpath+version+'/';
 const sourcePath = path.join(process.cwd(), sourceDirectoryRelative);

--- a/scripts/runAll.js
+++ b/scripts/runAll.js
@@ -1,12 +1,16 @@
+const UNRELEASED_VERSION = 'unreleased';
+
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { execSync } = require('child_process');
 
+const requestedVersion = process.argv.slice(2)[0] || UNRELEASED_VERSION
+
 // always regenerate 'latest'
 execSync('node scripts/generateDocs.js latest');
-execSync('node scripts/generateDocs.js ' + process.argv.slice(2)[0]);
+execSync('node scripts/generateDocs.js ' + requestedVersion);
 execSync('node scripts/generateContentMetadata.js');
 execSync('node scripts/generateDocumentationMetadata.js');
 
 // always regenerate 'latest'
 execSync('node scripts/generateApidocs.js latest');
-execSync('node scripts/generateApidocs.js ' + process.argv.slice(2)[0]);
+execSync('node scripts/generateApidocs.js ' + requestedVersion);

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -103,3 +103,5 @@ export const commitee = [
     title: '',
   },
 ]
+
+export const UNRELEASED_VERSION = 'unreleased'


### PR DESCRIPTION
And generate _content/api/version path when it's not there (on first install).
Tried using constants instead of having the "unreleased" string everywhere, but turns out importing was not supported in most cases so added local constant instead. Need to check how the constant could be shared properly. Maybe require() on the script files?