### PR TITLE
prevent navigation to closed submenu

### DIFF
--- a/styles/_navigation.scss
+++ b/styles/_navigation.scss
@@ -244,6 +244,7 @@
   &:not(.open) {
     height: 0;
     overflow: hidden;
+    display: none;
   }
   @media screen and (max-width: 1280px) {
     display: grid;


### PR DESCRIPTION
display: none for closed submenu so that navigation to subitems won't happen