### PR TITLE
Low hanging accessibility fruits

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -41,7 +41,7 @@ export default async function SingleBlogPage({
             <div className='breadcrumbs mb-8 text-sm'>
             <Link
                 href='/blog'
-                className='flex gap-2 font-bold items-center text-gray-400 transition'
+                className='flex gap-2 font-bold items-center text-gray-500 transition'
             >
                 <ArrowLeftIcon className='h-6 w-6' />
                 See all posts

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -113,7 +113,7 @@ export default function BlogsPage() {
             )}
           </div>
         </nav>
-        <div className='grid place-content-center text-center text-gray-400 text-sm'>
+        <div className='grid place-content-center text-center text-gray-500 text-sm'>
           {paginatedPosts && paginatedPosts.length > 0
             ? `Showing ${(currentPage - 1) * POSTS_PER_PAGE + 1} to ${Math.min(
                 currentPage * POSTS_PER_PAGE,

--- a/app/discover/functionalities/page.tsx
+++ b/app/discover/functionalities/page.tsx
@@ -30,7 +30,7 @@ export default function DiscoverPage() {
   }).sort((a, b) => b.date.getTime() - a.date.getTime());
 
   return (
-    <Layout heroSmall heroTitle='Discover Oskari'>
+    <Layout heroSmall heroTitle='Functionalities'>
       <Container
         style={{
           display: 'flex',

--- a/app/documentation/docs/[version]/[slug]/page.tsx
+++ b/app/documentation/docs/[version]/[slug]/page.tsx
@@ -12,6 +12,7 @@ import '@/styles/apidoc.scss'
 import '@fortawesome/fontawesome-free/js/fontawesome.min.js';
 import '@fortawesome/fontawesome-free/css/fontawesome.min.css';
 import '@fortawesome/fontawesome-free/css/solid.min.css';
+import ApiDocContentWrapper from '@/app/documentation/api/components/ApiDocContentWrapper'
 
 export const generateMetadata = async ({
   params,
@@ -91,7 +92,7 @@ export default async function SingleDocPage({
     <div>
       {activeSection ? (
         <div className='md-content max-w-[70ch] mt-7'>
-          <div dangerouslySetInnerHTML={{ __html: activeSection.html }}></div>
+          <ApiDocContentWrapper html={activeSection.html}/>
         </div>
     ) : (
         <h2>Document not found</h2>

--- a/components/Cards/Card.tsx
+++ b/components/Cards/Card.tsx
@@ -25,7 +25,7 @@ const Card = ({
           className={`${styles.card__cta} flex justify-between items-center`}
         >
           {tags && tags?.length > 0 && (
-            <span className='text-gray-300 text-xs font-medium me-2 px-2.5 py-0.5 rounded border border-gray-300'>
+            <span className='text-gray-500 text-xs font-medium me-2 px-2.5 py-0.5 rounded border border-gray-500'>
               {tags
                 .map(
                   (tag) =>
@@ -91,7 +91,7 @@ const Card = ({
             className={`${styles.card__cta} flex justify-between items-center`}
           >
             {tags && tags?.length > 0 && (
-              <span className='text-gray-300 text-xs font-medium me-2 px-2.5 py-0.5 rounded border border-gray-300'>
+              <span className='text-gray-500 text-xs font-medium me-2 px-2.5 py-0.5 rounded border border-gray-500'>
                 {tags
                   .map(
                     (tag) =>

--- a/styles/apidoc.scss
+++ b/styles/apidoc.scss
@@ -48,26 +48,28 @@ div.apidocContentWrapper {
   font-size: 1.125rem;
 }
 
-.add {
-  background-color : green;
-}
-
-.mod {
-  background-color : orange;
-}
-
-.rem {
-  background-color : red;
-}
-
-.breaking {
-  background-color : red;
-}
 
   /*badges*/
   span.label.label-primary {
     margin-left: 4px;
     margin-right: 4px;
+
+    &.add {
+      background-color : green;
+    }
+
+    &.mod {
+      background-color : orange;
+    }
+
+    &.rem {
+      background-color : red;
+    }
+
+    &.breaking {
+      background-color : red;
+    }
+
   }
 
   .label-primary {

--- a/styles/main.scss
+++ b/styles/main.scss
@@ -126,6 +126,8 @@ h3 {
 }
 
 .layout--docs {
+  overflow: hidden;
+  word-break: break-word;
   display: grid;
   gap: 4rem;
   grid-template-columns: 1fr 3fr;


### PR DESCRIPTION
-heading "discover" -> "functionalities"
-fixed low contrast in 'use case' - badges and bloglist paging
-content wrapping in mobile view
-bonus track: fixed the 'breaking', 'add' etc. badge colorings in apidocs which had been broken at some point