### PR TITLE
more compact layout and use same balloons on all pages

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -17,13 +17,8 @@ export default function Hero({
     ? styles['hero__content--small']
     : styles.hero__content
 
-  const heroImageClass = small
-    ? "bg-[url('/assets/images/hero-blob-small.svg')] h-[calc(500px+var(--navigation-height))] !bg-cover"
-    : "bg-[url('/assets/images/hero-blob.svg')] aspect-auto min-h-[100svh] lg:min-h-[unset] lg:h-auto lg:aspect-video pt-[calc(var(--navigation-height)+1rem)] pb-[calc(var(--navigation-height)*2+1rem)]"
   return (
-    <div
-      className={`relative full-width ${heroImageClass} bg-no-repeat bg-cover lg:bg-contain inset-0 lg:bg-center`}
-    >
+    <>
       <div className={`${heroClass}`}>
         <div className={heroContentClass}>
           <div>
@@ -53,6 +48,6 @@ export default function Hero({
           )}
         </div>
       </div>
-    </div>
+    </>
   )
 }

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -13,12 +13,23 @@ export default function Layout({
   heroSmall = false,
   heroTitle = 'Oskari – a mapping tool that adapts to your needs',
 }: LayoutProps) {
+  /*
+  let heroImageClass = heroSmall
+    ? "bg-[url('/assets/images/hero-blob-small.svg')] h-[calc(700px+var(--navigation-height))] !bg-cover"
+    : "bg-[url('/assets/images/hero-blob.svg')] min-h-[100svh] lg:min-h-[unset] lg:h-auto lg:aspect-video pt-[calc(var(--navigation-height)+1rem)]"
+  */
+  // lose the "small" option (for now at least). It's causing issues with the new dom-structure, now that the colored balls stay on the background instead of as a block-level node
+  const heroImageClass = "bg-[url('/assets/images/hero-blob.svg')] min-h-[100svh] lg:min-h-[unset] lg:h-auto lg:aspect-video pt-[calc(var(--navigation-height)+1rem)]";
   return (
     <>
       <Navigation />
-      <Hero small={heroSmall} title={heroTitle} />
-      <main className='content-wrapper content-grid'>{children}</main>
-      <Footer />
+      <div style={{ marginTop: '8rem'}}>
+        <div className={`full-width full-height ${heroImageClass} bg-no-repeat bg-cover lg:bg-contain inset-0 lg:bg-top`}>
+          <Hero small={heroSmall} title={heroTitle} />
+          <main className='content-wrapper content-grid'>{children}</main>
+        </div>
+        <Footer/>
+      </div>
     </>
   )
 }

--- a/styles/main.scss
+++ b/styles/main.scss
@@ -137,7 +137,7 @@ h3 {
 }
 
 .content-wrapper {
-  margin-top: 6rem;
+  margin-top: 3rem;
 }
 
 .content-grid,


### PR DESCRIPTION
-colored happy balloons as part of background instead of as a block-element
-same size balloons on all pages so fixed height wouldn't cause issues and also because the gained benefit was lowish
-up to debate whether the new approach with text on top of colored balloons is good or not.

NEW:
![image](https://github.com/oskariorg/oskari-documentation-site/assets/131667037/6f5eee82-e185-42d5-8ced-d80450759486)
![image](https://github.com/oskariorg/oskari-documentation-site/assets/131667037/1a3e11cd-b600-46f2-a0dd-fbe4467559fd)


OLD:
![image](https://github.com/oskariorg/oskari-documentation-site/assets/131667037/e6230105-eabf-494c-b52d-d8562b6def37)
![image](https://github.com/oskariorg/oskari-documentation-site/assets/131667037/e1ab8d41-8638-44de-822f-8e016884d00f)
 