### PR TITLE
Release notes attempt to fix

### DIFF
--- a/lib/markdownToHtml.test.ts
+++ b/lib/markdownToHtml.test.ts
@@ -1,5 +1,5 @@
 
-import { badgeTemplates, insertIdsToHeaders, processCodeBlocks, processHeaders, processJavascriptBlocks, processTripleQuoteCodeBlocks, updateMarkdownHtmlStyleTags, updateMarkdownImagePaths } from "./markdownToHtml";
+import { badgeTemplates, insertIdsToHeaders, processCodeBlocks, processHeaders, processJavascriptBlocks, processMigrationGuideLinks, processTripleQuoteCodeBlocks, updateMarkdownHtmlStyleTags, updateMarkdownImagePaths } from "./markdownToHtml";
 import slugify from 'slugify';
 
 const createTestHtml = () => {
@@ -197,4 +197,19 @@ describe('markdownToHtml tests', () => {
       expect(processed.startsWith('<code')).toBe(true);
     });
   });
+
+  describe('Link to migration guide', () => {
+    it('should replace migration guide link with anchor', () => {
+      const markdown = `[Migrationguide](MigrationGuide.md)`;
+      const markdownAfter = `<a href="#Migration-guide">Migrationguide</a>`;
+      const processed = processMigrationGuideLinks(markdown).trim();
+      expect(processed).toEqual(markdownAfter);
+    });
+
+    it('should leave link with absolute path alone', () => {
+      const markdown = `[Migrationguide](http://www.migrationguideland.com/MigrationGuide.md)`;
+      const processed = processMigrationGuideLinks(markdown).trim();
+      expect(processed).toEqual(markdown);
+    });
+  })
 });

--- a/lib/markdownToHtml.test.ts
+++ b/lib/markdownToHtml.test.ts
@@ -1,5 +1,5 @@
 
-import { badgeTemplates, insertIdsToHeaders, processCodeBlocks, processHeaders, processJavascriptBlocks, updateMarkdownHtmlStyleTags, updateMarkdownImagePaths } from "./markdownToHtml";
+import { badgeTemplates, insertIdsToHeaders, processCodeBlocks, processHeaders, processJavascriptBlocks, processTripleQuoteCodeBlocks, updateMarkdownHtmlStyleTags, updateMarkdownImagePaths } from "./markdownToHtml";
 import slugify from 'slugify';
 
 const createTestHtml = () => {
@@ -163,6 +163,27 @@ describe('markdownToHtml tests', () => {
           console.log(a + b);
         \`\`\``;
       const processed = processJavascriptBlocks(markdown).trim();
+      expect(processed.indexOf('´')).toBe(-1);
+      expect(processed.startsWith('<pre><code')).toBe(true);
+    });
+  });
+
+  describe('processing triplequote codeblocks', () => {
+    it ('should prepare triple quote - blocks for highlight.js', () => {
+      const markdown = "``` var a = 0;```";
+      const processed = processTripleQuoteCodeBlocks(markdown);
+      expect(processed.indexOf('´')).toBe(-1);
+      expect(processed.startsWith('<pre><code')).toBe(true);
+    });
+
+    it ('should be able to handle triple quote blocks with multiple lines', () => {
+      const markdown = `
+        \`\`\`
+          var a = 0;
+          let b = 3;
+          console.log(a + b);
+        \`\`\``;
+      const processed = processTripleQuoteCodeBlocks(markdown).trim();
       expect(processed.indexOf('´')).toBe(-1);
       expect(processed.startsWith('<pre><code')).toBe(true);
     });

--- a/lib/markdownToHtml.ts
+++ b/lib/markdownToHtml.ts
@@ -117,7 +117,6 @@ export const processTripleQuoteCodeBlocks = (markdownContent: string): string =>
   return replacedContent;
 }
 
-
 export const processCodeBlocks = (markdownContent: string): string => {
   const codeRegex = /`(.*?)`/g;
   const contentWithCodeBlocks = markdownContent.replace(codeRegex, (match, codeContent) => {
@@ -125,4 +124,14 @@ export const processCodeBlocks = (markdownContent: string): string => {
   });
 
   return contentWithCodeBlocks;
+}
+
+export const processMigrationGuideLinks = (markdownContent: string): string => {
+  const regex = /\[(.*?)\]\((MigrationGuide.md)\)/g;
+  const slugified = slugify('Migration guide');
+  const result = markdownContent.replaceAll(regex, (match, linkText) => {
+    // marked is constantly failing to recognize relative md-style links as links so we're we're using html here.
+    return `<a href="#${slugified}">${linkText}</a>`;
+  });
+  return result;
 }

--- a/lib/markdownToHtml.ts
+++ b/lib/markdownToHtml.ts
@@ -107,6 +107,17 @@ export const processJavascriptBlocks = (markdownContent: string) => {
   return replacedContent;
 }
 
+export const processTripleQuoteCodeBlocks = (markdownContent: string): string => {
+  const tripleQuoteRegex = /```\s*([^`]|\n)*```/g;
+  const replacedContent = markdownContent.replace(tripleQuoteRegex, (match) => {
+    const replaceTagRegex = /```/;
+    const codeContent = match.replace(replaceTagRegex, '').replace(replaceTagRegex, '').trim();
+    return `<pre><code class="hljs">${hljs.highlightAuto(codeContent).value}</code></pre>`;
+  });
+  return replacedContent;
+}
+
+
 export const processCodeBlocks = (markdownContent: string): string => {
   const codeRegex = /`(.*?)`/g;
   const contentWithCodeBlocks = markdownContent.replace(codeRegex, (match, codeContent) => {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -2,7 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import matter from 'gray-matter'
 import { MERMAID_SNIPPET, mdToHtml } from './customMarked'
-import { insertIdsToHeaders, processCodeBlocks, processHeaders, processJavascriptBlocks, updateMarkdownHtmlStyleTags, updateMarkdownImagePaths } from './markdownToHtml'
+import { insertIdsToHeaders, processCodeBlocks, processHeaders, processJavascriptBlocks, processTripleQuoteCodeBlocks, updateMarkdownHtmlStyleTags, updateMarkdownImagePaths } from './markdownToHtml'
 import { MarkdownFileMetadata, VersionDocType } from '@/types/types'
 export function slugify(input: string): string {
   return input
@@ -81,8 +81,9 @@ const processMarkdown = (markdown: string, imagesPath: string) => {
   markdown = updateMarkdownImagePaths(markdown, imagesPath);
   markdown = updateMarkdownHtmlStyleTags(markdown);
   markdown = processHeaders(markdown);
-  // these two are dependent to be run in this order
+  // these are dependent to be run in this order
   markdown = processJavascriptBlocks(markdown);
+  markdown = processTripleQuoteCodeBlocks(markdown);
   markdown = processCodeBlocks(markdown);
   return markdown;
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -2,7 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import matter from 'gray-matter'
 import { MERMAID_SNIPPET, mdToHtml } from './customMarked'
-import { insertIdsToHeaders, processCodeBlocks, processHeaders, processJavascriptBlocks, processTripleQuoteCodeBlocks, updateMarkdownHtmlStyleTags, updateMarkdownImagePaths } from './markdownToHtml'
+import { insertIdsToHeaders, processCodeBlocks, processHeaders, processJavascriptBlocks, processMigrationGuideLinks, processTripleQuoteCodeBlocks, updateMarkdownHtmlStyleTags, updateMarkdownImagePaths } from './markdownToHtml'
 import { MarkdownFileMetadata, VersionDocType } from '@/types/types'
 export function slugify(input: string): string {
   return input
@@ -81,6 +81,8 @@ const processMarkdown = (markdown: string, imagesPath: string) => {
   markdown = updateMarkdownImagePaths(markdown, imagesPath);
   markdown = updateMarkdownHtmlStyleTags(markdown);
   markdown = processHeaders(markdown);
+  markdown = processMigrationGuideLinks(markdown);
+
   // these are dependent to be run in this order
   markdown = processJavascriptBlocks(markdown);
   markdown = processTripleQuoteCodeBlocks(markdown);


### PR DESCRIPTION
-treat triplequote codeblocks the same as triplequotejavascript code blocks
-change links to migration guide.md to anchor in the generated document