### PR TITLE
Release notes attempt to fix

### DIFF
--- a/lib/markdownToHtml.ts
+++ b/lib/markdownToHtml.ts
@@ -126,11 +126,21 @@ export const processCodeBlocks = (markdownContent: string): string => {
   return contentWithCodeBlocks;
 }
 
+export const processAllLinks = (markdownContent: string): string => {
+  const linkRegex = /(?<!\!)\[([^\]]+)\]\(([^)]+)\)/g;
+  const result = markdownContent.replaceAll(linkRegex, (match, linkText, linkUrl) => {
+    // marked is constantly failing to recognize relative md-style links as links so we're using html here.
+    return `<a href="${linkUrl}">${linkText}</a>`;
+  });
+  return result;
+
+}
+
 export const processMigrationGuideLinks = (markdownContent: string): string => {
   const regex = /\[(.*?)\]\((MigrationGuide.md)\)/g;
   const slugified = slugify('Migration guide');
   const result = markdownContent.replaceAll(regex, (match, linkText) => {
-    // marked is constantly failing to recognize relative md-style links as links so we're we're using html here.
+    // marked is constantly failing to recognize relative md-style links as links so we're using html here.
     return `<a href="#${slugified}">${linkText}</a>`;
   });
   return result;

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -49,8 +49,18 @@ export const readAndConcatMarkdownFiles = async function(parentItem: MarkdownFil
     const cwdPath = path.resolve(process.cwd());
     const fullPath = path.normalize(path.join(cwdPath, element.path));
     const markdown = fs.readFileSync(fullPath, 'utf8');
-    const { content } = matter(markdown);
-    markdownAll += content;
+    let { content } = matter(markdown);
+
+    // TODO: this might be something other than 6. But on the other hand we might have other hierarchies that have
+    // changelog in the title so keeping this for now and dealing with this later if we need to.
+    // parentItem = the directory
+    // element = file.
+    // So, we are replacing every # heading with ## heading, unless it's the Changelog file itself...
+    if (parentItem.title.startsWith('6 Changelog') && element.fileName !== 'Changelog.md') {
+      content = replaceLevelOneHeadingsWithLevelTwo(content)
+    }
+
+    markdownAll += content +'\r\n';
   });
 
   markdownAll = processMarkdown(markdownAll, imagesPath);
@@ -75,6 +85,12 @@ export const readAndConcatMarkdownFiles = async function(parentItem: MarkdownFil
 /** cleans up html tags from a given string (used for cleaning up a heading from badges in documentation toc)  */
 export const cleanTags = (htmlString: string) => {
   return htmlString.replace(/<[^>]+>/g, '');
+}
+
+const replaceLevelOneHeadingsWithLevelTwo = (markdown: string): string => {
+  const headerRegex = /^# (.*)$/gm;
+  const replacedString = markdown.replace(headerRegex, '## $1');
+  return replacedString;
 }
 
 const processMarkdown = (markdown: string, imagesPath: string) => {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -60,7 +60,7 @@ export const readAndConcatMarkdownFiles = async function(parentItem: MarkdownFil
       content = replaceLevelOneHeadingsWithLevelTwo(content)
     }
 
-    markdownAll += content +'\r\n';
+    markdownAll += content +'\r\n\r\n';
   });
 
   markdownAll = processMarkdown(markdownAll, imagesPath);

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -2,7 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import matter from 'gray-matter'
 import { MERMAID_SNIPPET, mdToHtml } from './customMarked'
-import { insertIdsToHeaders, processCodeBlocks, processHeaders, processJavascriptBlocks, processMigrationGuideLinks, processTripleQuoteCodeBlocks, updateMarkdownHtmlStyleTags, updateMarkdownImagePaths } from './markdownToHtml'
+import { insertIdsToHeaders, processAllLinks, processCodeBlocks, processHeaders, processJavascriptBlocks, processMigrationGuideLinks, processTripleQuoteCodeBlocks, updateMarkdownHtmlStyleTags, updateMarkdownImagePaths } from './markdownToHtml'
 import { MarkdownFileMetadata, VersionDocType } from '@/types/types'
 export function slugify(input: string): string {
   return input
@@ -97,8 +97,10 @@ const processMarkdown = (markdown: string, imagesPath: string) => {
   markdown = updateMarkdownImagePaths(markdown, imagesPath);
   markdown = updateMarkdownHtmlStyleTags(markdown);
   markdown = processHeaders(markdown);
+  // migration guide first, specific treatment for that
   markdown = processMigrationGuideLinks(markdown);
-
+  //process rest of the links from md style -> <a href... to help the lib that's supposed to be doing this in its efforts.
+  markdown = processAllLinks(markdown);
   // these are dependent to be run in this order
   markdown = processJavascriptBlocks(markdown);
   markdown = processTripleQuoteCodeBlocks(markdown);

--- a/scripts/generateDocs.js
+++ b/scripts/generateDocs.js
@@ -42,7 +42,7 @@ fs.mkdirSync(pathToNewFiles, {recursive: true});
 const mdContent = `
 # Changelog
 
-In the following paragraphs we've listed an aggregated result of changes specific to this version of Oskari. Following the below links you can access full notes of different components.
+In the following paragraphs we've listed an aggregated result of changes specific to this version of Oskari. Following the links below you can access full notes of different components.
 
 - [Oskari frontend release notes](https://github.com/oskariorg/oskari-frontend/blob/master/ReleaseNotes.md)
 - [Oskari server release notes](https://github.com/oskariorg/oskari-server/blob/master/ReleaseNotes.md)

--- a/scripts/generateDocs.js
+++ b/scripts/generateDocs.js
@@ -38,7 +38,18 @@ const pathToServerRepository = path.join(pathToExternalRepos, 'oskari-server/');
 const pathToNewFiles = path.join(pathToVersionRoot, '/6 Changelog');
 // Init folder and heading file
 fs.mkdirSync(pathToNewFiles, {recursive: true});
-fs.writeFileSync(path.join(pathToNewFiles, "Changelog.md"), "# Changelog\n");
+
+const mdContent = `
+# Changelog
+
+In the following paragraphs we've listed an aggregated result of changes specific to this version of Oskari. Following the below links you can access full notes of different components.
+
+- [Oskari frontend release notes](https://github.com/oskariorg/oskari-frontend/blob/master/ReleaseNotes.md)
+- [Oskari server release notes](https://github.com/oskariorg/oskari-server/blob/master/ReleaseNotes.md)
+- [Migration guide](https://github.com/oskariorg/oskari-server/blob/master/MigrationGuide.md)
+`;
+
+fs.writeFileSync(path.join(pathToNewFiles, "Changelog.md"), mdContent);
 
 // Create a summary section highlighting the changes in new version from these files
 const filesToHandle = {


### PR DESCRIPTION
-fix changelog headings
-add links to full release notes & migration guide
-process md-style links manually (transform to html). Had too many problems relying on marked to be able to handle this

![image](https://github.com/oskariorg/oskari-documentation-site/assets/131667037/c9c7d573-39b6-420d-8565-adab937a673a)
 