### PR TITLE
Setup instructions revised

### DIFF
--- a/lib/markdownToHtml.ts
+++ b/lib/markdownToHtml.ts
@@ -145,3 +145,38 @@ export const processMigrationGuideLinks = (markdownContent: string): string => {
   });
   return result;
 }
+
+const findLinksToMDDocs = (mdString: string) => {
+  //find all html-style links that have data-internal-anchor - attribute set
+  //and replace thos with links to internal anchors
+  const linkRegex = /<a\b[^>]*\bdata-internal-anchor[^>]*>(.*?)<\/a>/gi;
+  const links = [];
+  let match;
+  while ((match = linkRegex.exec(mdString)) !== null) {
+    links.push({
+      html: match[0],
+      text: match[1]
+    });
+  }
+
+  return links;
+}
+
+export const processInternalMDLinks = (mdString: string): string => {
+  const links = findLinksToMDDocs(mdString);
+  links.forEach(link => {
+    const hrefRegex = /href=["']([^"']+)["']/i;
+    const datalinkRegex =  /data-internal-anchor=["']([^"']+)["']/i;
+    const datalinkMatch = datalinkRegex.exec(link.html);
+
+    if (datalinkMatch) {
+      const datalinkRef = datalinkMatch[1];
+      const slugifiedHref = slugify(datalinkRef);
+      const newLinkHtml = link.html.replace(hrefRegex, `href="#${slugifiedHref}"`);
+      mdString = mdString.replace(link.html, newLinkHtml);
+    }
+  });
+
+  return mdString;
+}
+

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -2,17 +2,8 @@ import fs from 'fs'
 import path from 'path'
 import matter from 'gray-matter'
 import { MERMAID_SNIPPET, mdToHtml } from './customMarked'
-import { insertIdsToHeaders, processAllLinks, processCodeBlocks, processHeaders, processJavascriptBlocks, processMigrationGuideLinks, processTripleQuoteCodeBlocks, updateMarkdownHtmlStyleTags, updateMarkdownImagePaths } from './markdownToHtml'
+import { insertIdsToHeaders, processAllLinks, processCodeBlocks, processHeaders, processInternalMDLinks, processJavascriptBlocks, processMigrationGuideLinks, processTripleQuoteCodeBlocks, updateMarkdownHtmlStyleTags, updateMarkdownImagePaths } from './markdownToHtml'
 import { MarkdownFileMetadata, VersionDocType } from '@/types/types'
-export function slugify(input: string): string {
-  return input
-    .toLowerCase()
-    .replace(/[^\w\s.-]/g, '') // Remove special characters
-    .replace(/[\s]+/g, '-') // Replace spaces with hyphens
-    .replace(/[-]+/g, '-') // Replace consecutive hyphens with a single hyphen
-    .replace(/\.md$/, '') // Remove the ".md" extension
-    .trim() // Trim leading/trailing whitespace
-}
 
 function compileMarkdownToHTML(markdown: string, startingSectionNumber: string): {
   html: string
@@ -101,6 +92,9 @@ const processMarkdown = (markdown: string, imagesPath: string) => {
   markdown = processMigrationGuideLinks(markdown);
   //process rest of the links from md style -> <a href... to help the lib that's supposed to be doing this in its efforts.
   markdown = processAllLinks(markdown);
+  //documentation internal links to other mds to work with the compiled version
+  markdown = processInternalMDLinks(markdown);
+
   // these are dependent to be run in this order
   markdown = processJavascriptBlocks(markdown);
   markdown = processTripleQuoteCodeBlocks(markdown);

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -25,7 +25,7 @@ export const NAVIGATION_ITEMS: Array<NavigationItemType> = [
   },
   {
     name: 'Documentation',
-    path: '/documentation/docs',
+    path: '/documentation/docs/latest/',
     children: [
       {
         name: 'FAQ',


### PR DESCRIPTION
replace 'internal' links href from the md-reference that works on github to that provided in "data-internal-anchor" - attribute.

This is far from ideal, but since the original references are to md documents whereas in new oskari org the anchors are created based on headings inside the file this was he first solution that came to mind.

the corresponding pr in documentation: https://github.com/oskariorg/oskari-documentation/pull/6