### PR TITLE
lose ordinal from sorting inside a folder'

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -56,7 +56,7 @@ export const readAndConcatMarkdownFiles = async function(parentItem: MarkdownFil
 
   markdownAll = processMarkdown(markdownAll, imagesPath);
 
-  const compiled = compileMarkdownToHTML(markdownAll, parentItem.ordinal);
+  const compiled = compileMarkdownToHTML(markdownAll, parentItem.ordinal || '1');
   // inject script to make mermaid js work its magic
   if (compiled.html.includes(MERMAID_SNIPPET)) {
     compiled.html += `<script src="https://cdn.jsdelivr.net/npm/mermaid@10.6.1/dist/mermaid.min.js"></script>

--- a/scripts/generateDocumentationMetadata.js
+++ b/scripts/generateDocumentationMetadata.js
@@ -32,10 +32,6 @@ function sortByParagraphNumber(a, b) {
     return aParts.length - bParts.length;
 }
 
-function sortByOrdinal(itemA, itemB) {
-    return itemA?.ordinal - itemB.ordinal;
-}
-
 function listContentsRecursively(fullPath, docsRelativePath, results = []) {
     const filesAndDirectories = fs.readdirSync(fullPath, { withFileTypes: true });
     filesAndDirectories.sort(sortByParagraphNumber);
@@ -44,7 +40,7 @@ function listContentsRecursively(fullPath, docsRelativePath, results = []) {
         const itemRelativePath = path.join(docsRelativePath, item.name);
         if (item.isDirectory() && item.name !== 'resources') {
             const sectionNumber = path.basename(itemPath).split(' ')[0];
-            const children = listContentsRecursively(itemPath, itemRelativePath)?.sort(sortByOrdinal);
+            const children = listContentsRecursively(itemPath, itemRelativePath)?.sort();
             results.push({
                 slug: slugify(item.name),
                 path: itemRelativePath,
@@ -54,13 +50,14 @@ function listContentsRecursively(fullPath, docsRelativePath, results = []) {
             });
         } else {
             if (path.extname(itemPath).toLowerCase() === '.md') {
-                const { data } = getFrontmatter(itemPath);
-                const fileNameWithoutExtension = path.parse(item.name).name;
+                let fileNameWithoutExtension = path.parse(item.name).name;
+                if (fileNameWithoutExtension.indexOf('-') > -1) {
+                    fileNameWithoutExtension = fileNameWithoutExtension.split('-')[1] || fileNameWithoutExtension;
+                }
                 const slug = slugify(fileNameWithoutExtension);
                 results.push({
                     path: itemRelativePath,
                     fileName: item.name,
-                    ...data,
                     slug
                 });
             }

--- a/scripts/generateDocumentationMetadata.js
+++ b/scripts/generateDocumentationMetadata.js
@@ -1,15 +1,9 @@
 /*eslint @typescript-eslint/no-var-requires: 0*/
 const fs = require('fs');
 const path = require('path');
-const grayMatter = require('gray-matter');
 const slugify = require('slugify');
 const syncResources = require('./syncResourcesFolder');
 const { generateDocumentationMetadata, getSubdirectories } = require('./documentationMetadataHelper');
-
-function getFrontmatter(filePath) {
-    const fileContent = fs.readFileSync(filePath, 'utf8');
-    return grayMatter(fileContent);
-}
 
 function sortByParagraphNumber(a, b) {
     // directories first

--- a/types/types.ts
+++ b/types/types.ts
@@ -44,7 +44,7 @@ export type VersionDocType = {
 export type MarkdownFileMetadata = {
   path: string,
   fileName: string,
-  ordinal: string,
+  ordinal?: string,
   slug: string,
   title: string,
   anchorLinks: Array<DocAnchorLinksType>,


### PR DESCRIPTION
removed ordinal from source files - using filename for sorting so it's the same in github & application