### PR TITLE
add scroll margin so scrolling to anchors in documentation works

### DIFF
--- a/styles/apidoc.scss
+++ b/styles/apidoc.scss
@@ -1,3 +1,8 @@
+/*fix elements sliding away from view when clicking links in documentation.*/
+html {
+  scroll-padding-top: 5em;
+}
+
 div.overFlowHidden {
   overflow: hidden;
 }


### PR DESCRIPTION
Unsatisfying but seems to work and on the other hand it doesn't seem to ruin the party for all other sections of the app.