### PR TITLE
add max-width to fix overflow/wrap issue

### DIFF
--- a/styles/apidoc.scss
+++ b/styles/apidoc.scss
@@ -10,6 +10,7 @@ div.overFlowHidden {
 div.apidocContentWrapper {
   overflow: hidden;
   word-wrap: break-word;
+  max-width: 85vw;
 
   table {
     font-size: 0.8em;


### PR DESCRIPTION
Used to hide overflowing text on narrow screen. Doesn't anymore.

![image](https://github.com/user-attachments/assets/e3839596-848a-4534-a67b-8b63d71a1bf3)
