### PR TITLE
indexJSON fetch by version, remove useless flag

### DIFF
--- a/app/documentation/docs/[version]/[slug]/page.tsx
+++ b/app/documentation/docs/[version]/[slug]/page.tsx
@@ -12,21 +12,47 @@ import '@fortawesome/fontawesome-free/css/solid.min.css';
 import ApiDocContentWrapper from '@/app/documentation/api/components/ApiDocContentWrapper'
 import AccordionListWrapper from '@/app/documentation/docs/[version]/[slug]/AccordionListWrapper'
 
-let indexJSON: MarkdownFileMetadata[] | null = null;
+let indexJSON: { [key: string]: MarkdownFileMetadata[] } = {};
+
 export const generateMetadata = async ({
   params,
 }: {
   params: { slug: string; version: string }
 }) => {
-  if (!indexJSON) {
-    indexJSON = await getVersionIndex(params.version, true);
-  }
-  const section = indexJSON?.find((item: MarkdownFileMetadata) => item.slug === params.slug);
+  await initIndexJSON(params.version)
+  const section = indexJSON[params.version]?.find((item: MarkdownFileMetadata) => item.slug === params.slug);
 
   if (section) {
     return { title: section.title }
   }
 
+}
+
+const renderAccordionContent = (
+  items: Array<DocAnchorLinksType>, parentSlug: string
+) => {
+  return (
+    <ul className={styles.accordionMenu}>
+      {items?.map((item, index) => (
+        <li key={item.slug + '_' + index}>
+          <Link
+            href={item.slug === parentSlug ? item.slug : parentSlug + '#' + item.slug}
+          >
+            {item.sectionNumber} {cleanTags(item.content)}
+          </Link>
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+const initIndexJSON = async (version: string) => {
+  if (!indexJSON || !indexJSON[version]) {
+    if (!indexJSON) {
+      indexJSON = {};
+    }
+    indexJSON[version] = await getVersionIndex(version);
+  }
 }
 
 export default async function SingleDocPage({
@@ -37,11 +63,8 @@ export default async function SingleDocPage({
 
 
   const { version } = params;
-  if (!indexJSON) {
-    indexJSON = await getVersionIndex(version, true);
-  }
-
-  const activeSection = indexJSON?.find((item: MarkdownFileMetadata) => item.slug === params.slug);
+  await initIndexJSON(params.version)
+  const activeSection = indexJSON[version]?.find((item: MarkdownFileMetadata) => item.slug === params.slug);
   const path = activeSection?.children[0].path;
   if (!activeSection || !path) {
     return <Error text='No documents found' code='404' />;
@@ -59,7 +82,7 @@ export default async function SingleDocPage({
     <div style={{ display: 'flex', flexDirection: 'column', gap: '2rem' }}>
       <VersionSidebar selectedVersion={params.version} versions={versions} baseHref='/documentation/docs/' />
       <AccordionGroup>
-        <AccordionListWrapper items={indexJSON} initialOpenSections={[activeSection.slug]}/>
+        <AccordionListWrapper items={indexJSON[params.version]} initialOpenSections={[activeSection.slug]}/>
       </AccordionGroup>
     </div>
     <div>

--- a/app/documentation/docs/[version]/[slug]/page.tsx
+++ b/app/documentation/docs/[version]/[slug]/page.tsx
@@ -28,24 +28,6 @@ export const generateMetadata = async ({
 
 }
 
-const renderAccordionContent = (
-  items: Array<DocAnchorLinksType>, parentSlug: string
-) => {
-  return (
-    <ul className={styles.accordionMenu}>
-      {items?.map((item, index) => (
-        <li key={item.slug + '_' + index}>
-          <Link
-            href={item.slug === parentSlug ? item.slug : parentSlug + '#' + item.slug}
-          >
-            {item.sectionNumber} {cleanTags(item.content)}
-          </Link>
-        </li>
-      ))}
-    </ul>
-  )
-}
-
 const initIndexJSON = async (version: string) => {
   if (!indexJSON || !indexJSON[version]) {
     if (!indexJSON) {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -17,21 +17,19 @@ function compileMarkdownToHTML(markdown: string, startingSectionNumber: string):
     anchorLinks,
   }
 }
-export async function getVersionIndex(version: string, fetchHtmlContent: boolean = false) {
+export async function getVersionIndex(version: string) {
   const rootFolder = `_content/docs/${version}`;
   if (!fs.existsSync(rootFolder) || !fs.statSync(rootFolder).isDirectory()) {
     return null;
   }
   const indexJSON = (await import(`_content/docs/${version}/index.js`)).default;
 
-  if (fetchHtmlContent) {
-    const imagesRuntimePath = '/assets/docs/' + version + '/resources/';
-    await indexJSON.forEach(async (element: MarkdownFileMetadata) => {
-      const { html, anchorLinks } = await readAndConcatMarkdownFiles(element, imagesRuntimePath, indexJSON, element.title);
-      element.anchorLinks = anchorLinks;
-      element.html = html;
-    });
-  }
+  const imagesRuntimePath = '/assets/docs/' + version + '/resources/';
+  await indexJSON.forEach(async (element: MarkdownFileMetadata) => {
+    const { html, anchorLinks } = await readAndConcatMarkdownFiles(element, imagesRuntimePath, indexJSON, element.title);
+    element.anchorLinks = anchorLinks;
+    element.html = html;
+  });
 
   return indexJSON;
 }


### PR DESCRIPTION
Fix the consequences of bad luck in thinking which occurred on first implementation (=read and store the index per version).

