### PR TITLE
Tuning the theme variables and update mermaid

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -65,21 +65,35 @@ export const readAndConcatMarkdownFiles = async function(parentItem: MarkdownFil
   markdownAll = processMarkdown(markdownAll, imagesPath, indexJSON, activeSectionSlug);
 
   const compiled = compileMarkdownToHTML(markdownAll, parentItem.ordinal || '1');
-  // inject script to make mermaid js work its magic
-  if (compiled.html.includes(MERMAID_SNIPPET)) {
-    compiled.html += `<script src="https://cdn.jsdelivr.net/npm/mermaid@10.6.1/dist/mermaid.min.js"></script>
+  compiled.html = injectMermaid(compiled.html);
+  return compiled;
+};
+
+// inject script to make mermaid js work its magic
+const injectMermaid = (htmlContent: string) => {
+  if (!htmlContent || !htmlContent.includes(MERMAID_SNIPPET)) {
+    // Mermaid syntax not present, return as-is
+    return htmlContent;
+  }
+  // Inject script at the end
+  return htmlContent + `<script src="https://cdn.jsdelivr.net/npm/mermaid@11.2.0/dist/mermaid.min.js"></script>
     <script>
     mermaid.initialize({
       startOnLoad:true,
       htmlLabels:true,
-      theme: 'base'
+      theme: 'base',
+      themeVariables: {
+        primaryColor: '#ffd400',
+        primaryTextColor: '#222222',
+        primaryBorderColor: 'rgb(163, 196, 188)',
+        lineColor: '#F8B229',
+        secondaryColor: 'rgb(163, 196, 188)',
+        tertiaryColor: '#f00'
+      }
     });
     </script>
-    `
-  }
-
-  return compiled;
-};
+    `;
+}
 
 
 /** Return true if this is a file under <nn> Changelog but not the changelog.md file itself, cos that's a no 1 heading we DO wanna keep. */

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -85,15 +85,15 @@ const injectMermaid = (htmlContent: string) => {
       themeVariables: {
         primaryColor: '#ffd400',
         primaryTextColor: '#222222',
-        primaryBorderColor: 'rgb(163, 196, 188)',
-        lineColor: '#F8B229',
-        secondaryColor: 'rgb(163, 196, 188)',
-        tertiaryColor: '#f00'
+        primaryBorderColor: '#222222',
+        lineColor: '#222222',
+        secondaryColor: '#A3C4BC'
       }
     });
     </script>
     `;
 }
+// ThemeVariables could also have tertiaryColor: '#f00'
 
 
 /** Return true if this is a file under <nn> Changelog but not the changelog.md file itself, cos that's a no 1 heading we DO wanna keep. */


### PR DESCRIPTION
- Update mermaid to newer version.
- Try fiddling with theme variables: they seem to make more sense on `sequenceDiagram` type of a diagram than on a `mindmap` one.

Tried using next/Script tag to load mermaid and have it on dependencies, but the Script-tag doesn't support using stuff from node_modules. Even using it we should have the script in the static `public` folder and the onReady-hook doesn't work if we don't force it to render on browser.