### PR TITLE
download page items revisited

### DIFF
--- a/app/download/page.tsx
+++ b/app/download/page.tsx
@@ -8,7 +8,6 @@ import { LATEST_STABLE_VERSION, UNRELEASED_VERSION } from '@/utils/constants'
 import { compareSemanticVersions } from '@/utils/misc'
 import { getVersionIndex } from '@/lib/utils'
 import { MarkdownFileMetadata } from '@/types/types'
-import Link from 'next/link'
 
 export const metadata: Metadata = {
   title: 'Download',

--- a/app/download/page.tsx
+++ b/app/download/page.tsx
@@ -3,54 +3,62 @@ import IconCard from '@/components/Cards/IconCard'
 import HighlightBox from '@/components/HighlightBox'
 import Layout from '@/components/Layout'
 import { Metadata } from 'next'
+import availableVersions from '@/_content/docs';
+import { LATEST_STABLE_VERSION, UNRELEASED_VERSION } from '@/utils/constants'
+import { compareSemanticVersions } from '@/utils/misc'
+import { getVersionIndex } from '@/lib/utils'
+import { MarkdownFileMetadata } from '@/types/types'
+import Link from 'next/link'
 
 export const metadata: Metadata = {
   title: 'Download',
 }
 
-export default function DownloadPage() {
+const findLatestVersionNumber = (): string => {
+  const versions = availableVersions
+    .filter((version) => version !== UNRELEASED_VERSION && version !== LATEST_STABLE_VERSION)
+    .sort((a, b) => compareSemanticVersions(a, b))
+    .reverse();
+
+  return versions && versions[0] ? versions[0] : 'latest';
+}
+
+const findSlugForSection = async (versionNumber: string, title: string) => {
+  const index = await getVersionIndex(versionNumber);
+  const setupInstructionsSlug = index.filter((item: MarkdownFileMetadata) => item?.title?.indexOf(title) > -1);
+  return setupInstructionsSlug && setupInstructionsSlug[0] ? setupInstructionsSlug[0].slug : '';
+}
+
+export default async function DownloadPage() {
+
+  const versionNumber = findLatestVersionNumber();
+  const setupInstructionsSlug = await findSlugForSection(versionNumber, 'Setup instructions');
+  const releaseNotesSlug = await findSlugForSection(versionNumber, 'Changelog');
+
   return (
     <Layout heroTitle='Download' heroSmall>
       <div className='my-24 flex flex-wrap justify-center gap-16 items-start'>
         <IconCard
           className='!bg-[var(--color-accent)]'
           title='Latest version'
-          subtitle='2.12.1'
           content={
             <>
-              <div className='mb-8'>
-                The UI has seen a number of improvements for users with small
-                screens. There has also been improvements in map layer
-                management.
-              </div>
               <div className='flex justify-center'>
                 <Button
                   variant='dark'
-                  title='Download'
+                  title={ 'Download ' + versionNumber}
                   href='https://oskari.org/build/server/oskari-latest-stable.zip'
                   external
                 />
               </div>
-            </>
-          }
-        />
-        <IconCard
-          className='!bg-[var(--color-accent)]'
-          title='Other versions'
-          content={
-            <>
-              <div className='mb-8'>
-                Have a look of the release notes of the previous Oskari
-                versions.
-              </div>
-              <div className='flex justify-center'>
-                <Button
-                  variant='dark'
-                  title='Release notes'
-                  href='https://github.com/oskariorg/oskari-frontend/blob/master/ReleaseNotes.md'
-                  external
-                  newWindow
-                />
+              <div className='flex flex-col justify-center '>
+                <div className='mt-8 mb-4'>
+                  See what changed in the latest version.
+                </div>
+                <div className="flex justify-center">
+                  <Button variant='dark' title={'Release notes'} href={'/documentation/docs/'+versionNumber+'/'+releaseNotesSlug}/> <br/>
+                </div>
+
               </div>
             </>
           }
@@ -61,8 +69,17 @@ export default function DownloadPage() {
         <Button
           variant='dark'
           title='Read installation instructions'
-          href='/documentation/docs'
+          href={'/documentation/docs/'+versionNumber+'/'+setupInstructionsSlug}
         />
+
+        <h2 className='mb-8 mt-8'>Download old versions</h2>
+        <Button
+          variant='dark'
+          title='Download from archive'
+          external={true}
+          href='https://download.osgeo.org/oskari/'
+        />
+
       </HighlightBox>
     </Layout>
   )


### PR DESCRIPTION
attempt to replace the lorem ipsum on downlaod page with actual content
-release notes - button to release notes of actual version
-ditch the "other versions" card from the mainsection. Move to the otter-section and just link to osgeo archive download. 

![image](https://github.com/user-attachments/assets/307c7ae4-bb61-48f7-8fb7-f129cfdea01b)
