### PR TITLE
Change refs from oskari-docs to oskari-documentation for issue reports

### DIFF
--- a/_content/faq/faq-developers.md
+++ b/_content/faq/faq-developers.md
@@ -4,7 +4,7 @@ You found a bug? Can you repeat it? Yes: file a bug report at GitHub issues.
 
 - Go to: [Oskari's GitHub page](https://github.com/oskariorg)
 - Sign up
-- Click **New issue** button
+- Click **New issue** button on [oskari-documentation](https://github.com/oskariorg/oskari-documentation/issues) repository
 - Include helpful information: what Oskari version you used, with what browser and what are the steps to reproduce the error
 - Click **Submit new issue**
 

--- a/app/contribute/page.tsx
+++ b/app/contribute/page.tsx
@@ -34,7 +34,7 @@ export default function ContributePage() {
               <div>
                 If you encounter a problem while using Oskari, please report it to us - {' '}
                 <a
-                  href='https://github.com/oskariorg/oskari-docs/issues'
+                  href='https://github.com/oskariorg/oskari-documentation/issues'
                   target='_blank'
                   rel='noopener noreferrer'
                 >
@@ -51,7 +51,7 @@ export default function ContributePage() {
               <div>
                 By{' '}
                 <a
-                  href='https://github.com/oskariorg/oskari-docs/pulls'
+                  href='https://github.com/oskariorg/oskari-documentation/pulls'
                   target='_blank'
                   rel='noopener noreferrer'
                 >
@@ -67,7 +67,7 @@ export default function ContributePage() {
             content={
               <div>
                 <a
-                  href='https://github.com/oskariorg/oskari-docs/issues'
+                  href='https://github.com/oskariorg/oskari-documentation/issues'
                   target='_blank'
                   rel='noopener noreferrer'
                 >


### PR DESCRIPTION
As we are moving out of oskari-docs (hosts the code for old version of oskari.org website) to the new oskari-documentation repository.