### PR TITLE
use marked custom renderer for codeblocks

### DIFF
--- a/lib/customMarked.ts
+++ b/lib/customMarked.ts
@@ -1,4 +1,6 @@
 import { marked } from 'marked'
+import hljs from 'highlight.js';
+import 'highlight.js/scss/a11y-dark.scss';
 
 marked.use({
     gfm: true,
@@ -9,4 +11,15 @@ export const MERMAID_SNIPPET = '<pre class="mermaid">'
 // Just a wrapper for marker renderer so we could tune how different html-tags are processed
 // but most of the special handling is in markdownToHtml.ts
 const renderer = new marked.Renderer();
+
+renderer.code = (code: string, infostring?: string): string => {
+  if (infostring && infostring === 'mermaid') {
+    return `<pre class="mermaid">${code}</pre>`;
+  } else if (infostring) {
+    return `<pre><code class="language-${infostring} hljs">${hljs.highlightAuto(code).value}</code></pre>`;
+  }
+
+  return `<pre><code>${code}</code></pre>`;
+};
+
 export const mdToHtml = (src: string) => marked(src, { renderer: renderer })

--- a/lib/markdownToHtml.test.ts
+++ b/lib/markdownToHtml.test.ts
@@ -1,5 +1,5 @@
 
-import { badgeTemplates, insertIdsToHeaders, processAllLinks, processCodeBlocks, processHeaders, processInternalMDLinks, processLanguageSpecificCodeBlocks, processMigrationGuideLinks, processTripleQuoteCodeBlocks, processMermaidCodeBlocks, updateMarkdownHtmlStyleTags, updateMarkdownImagePaths } from "./markdownToHtml";
+import { badgeTemplates, insertIdsToHeaders, processAllLinks, processHeaders, processInternalMDLinks, processMigrationGuideLinks, updateMarkdownHtmlStyleTags, updateMarkdownImagePaths } from "./markdownToHtml";
 import slugify from 'slugify';
 
 const createTestHtml = () => {
@@ -156,63 +156,6 @@ describe('markdownToHtml tests', () => {
     })
   });
 
-  describe('processing code blocks where language is specified', () => {
-    const langs = ['javascript', 'java', 'sql', 'json'];
-
-    it ('should prepare a block in given language for highlight.js', () => {
-      langs.forEach((lang) => {
-        const markdown = "```" + lang + " var a = 0;```";
-        const processed = processLanguageSpecificCodeBlocks(markdown, lang);
-        expect(processed.indexOf('´')).toBe(-1);
-        expect(processed.startsWith('<pre><code class="language-' + lang)).toBe(true);
-      });
-    });
-
-    it ('should be able to handle code blocks in given language with multiple lines', () => {
-      langs.forEach((lang) => {
-        const markdown = `
-        \`\`\`${lang}
-          var a = 0;
-          let b = 3;
-          console.log(a + b);
-        \`\`\``;
-        const processed = processLanguageSpecificCodeBlocks(markdown, lang).trim();
-        expect(processed.indexOf('´')).toBe(-1);
-        expect(processed.startsWith('<pre><code class="language-' + lang)).toBe(true);
-      });
-    });
-  });
-
-  describe('processing triplequote codeblocks', () => {
-    it ('should prepare triple quote - blocks for highlight.js', () => {
-      const markdown = "``` var a = 0;```";
-      const processed = processTripleQuoteCodeBlocks(markdown);
-      expect(processed.indexOf('´')).toBe(-1);
-      expect(processed.startsWith('<pre><code')).toBe(true);
-    });
-
-    it ('should be able to handle triple quote blocks with multiple lines', () => {
-      const markdown = `
-        \`\`\`
-          var a = 0;
-          let b = 3;
-          console.log(a + b);
-        \`\`\``;
-      const processed = processTripleQuoteCodeBlocks(markdown).trim();
-      expect(processed.indexOf('´')).toBe(-1);
-      expect(processed.startsWith('<pre><code')).toBe(true);
-    });
-  });
-
-  describe('processing codeblocks', () => {
-    it ('should prepare code - blocks', () => {
-      const markdown = "`var a = 0;`";
-      const processed = processCodeBlocks(markdown).trim();
-      expect(processed.indexOf('´')).toBe(-1);
-      expect(processed.startsWith('<code')).toBe(true);
-    });
-  });
-
   describe('Link to migration guide', () => {
     it('should replace migration guide link with anchor', () => {
       const markdown = `[Migrationguide](MigrationGuide.md)`;
@@ -316,19 +259,6 @@ describe('markdownToHtml tests', () => {
       const activeSectionTitle = "Section One";
       const result = processInternalMDLinks(markdownContent, indexJSON, activeSectionTitle);
       expect(result).toBe("This content has no links.");
-    });
-  });
-
-  describe('processing mermaid codeblocks', () => {
-    it ('should ignore non-mermaid code-blocks', () => {
-      const markdown = "``` var a = 0;```";
-      const processed = processMermaidCodeBlocks(markdown);
-      expect(processed).toEqual(markdown);
-    });
-    it ('should wrap mermaid content to HTML pre.mermaid', () => {
-      const markdown = "```mermaid\ntesting stuff```";
-      const processed = processMermaidCodeBlocks(markdown);
-      expect(processed.startsWith('<pre class="mermaid">testing stuff</pre>')).toEqual(true);
     });
   });
 });

--- a/lib/markdownToHtml.ts
+++ b/lib/markdownToHtml.ts
@@ -1,8 +1,6 @@
 import { DocAnchorLinksType, MarkdownFileMetadata } from '@/types/types';
 import slugify from 'slugify';
-import hljs from 'highlight.js';
 import 'highlight.js/scss/a11y-dark.scss';
-import { MERMAID_SNIPPET } from './customMarked';
 
 export const insertIdsToHeaders = (htmlString: string, startingSectionNumber: string) => {
   const headerRegex = /<h([1-3])>(.*?)<\/h\1>/g
@@ -113,51 +111,6 @@ export const processHeaders = (markdownContent:string): string => {
   return processedContent;
 }
 
-export const processMermaidCodeBlocks = (markdownContent: string) => {
-  //const codeRegex = /```javascript\s*([^`]|\n)*```/g;
-  const codeRegex = new RegExp(`\`\`\`mermaid\\s*([^\\\`]|\\n)*\`\`\``, 'g')
-
-  const replacedContent = markdownContent.replace(codeRegex, (match) => {
-    const startTagRegex = new RegExp(`\`\`\`mermaid`);
-    const endTagRegex = /```/;
-    const codeContent = match.replace(startTagRegex, '').replace(endTagRegex, '').trim();
-    return `${MERMAID_SNIPPET}${codeContent}</pre>`;
-  });
-  return replacedContent;
-}
-
-export const processLanguageSpecificCodeBlocks = (markdownContent: string, language: string) => {
-  //const codeRegex = /```javascript\s*([^`]|\n)*```/g;
-  const codeRegex = new RegExp(`\`\`\`${language}\\s*([^\\\`]|\\n)*\`\`\``, 'g')
-
-  const replacedContent = markdownContent.replace(codeRegex, (match) => {
-    const startTagRegex = new RegExp(`\`\`\`${language}`);
-    const endTagRegex = /```/;
-    const codeContent = match.replace(startTagRegex, '').replace(endTagRegex, '').trim();
-    return `<pre><code class="language-${language} hljs">${hljs.highlightAuto(codeContent).value}</code></pre>`;
-  });
-  return replacedContent;
-}
-
-export const processTripleQuoteCodeBlocks = (markdownContent: string): string => {
-  const tripleQuoteRegex = /```\s*([^`]|\n)*```/g;
-  const replacedContent = markdownContent.replace(tripleQuoteRegex, (match) => {
-    const replaceTagRegex = /```/;
-    const codeContent = match.replace(replaceTagRegex, '').replace(replaceTagRegex, '').trim();
-    return `<pre><code class="hljs">${hljs.highlightAuto(codeContent).value}</code></pre>`;
-  });
-  return replacedContent;
-}
-
-export const processCodeBlocks = (markdownContent: string): string => {
-  const codeRegex = /`(.*?)`/g;
-  const contentWithCodeBlocks = markdownContent.replace(codeRegex, (match, codeContent) => {
-    return `<code>${codeContent}</code>`;
-  });
-
-  return contentWithCodeBlocks;
-}
-
 export const processAllLinks = (markdownContent: string): string => {
   const linkRegex = /(?<!\!)\[([^\]]+)\]\(([^)]+)\)/g;
   const result = markdownContent.replaceAll(linkRegex, (match, linkText, linkUrl) => {
@@ -177,66 +130,6 @@ export const processMigrationGuideLinks = (markdownContent: string): string => {
   });
   return result;
 }
-
-/*
-const findLinksToMDDocs = (mdString: string) => {
-  //find all html-style links that have data-internal-anchor - attribute set
-  //and replace thos with links to internal anchors
-  const linkRegex = /<a\b[^>]*\bdata-internal-anchor[^>]*>(.*?)<\/a>/gi;
-  const links = [];
-  let match;
-  while ((match = linkRegex.exec(mdString)) !== null) {
-    links.push({
-      html: match[0],
-      text: match[1]
-    });
-  }
-
-  return links;
-}
-
-export const processInternalMDLinks = (mdString: string): string => {
-  const links = findLinksToMDDocs(mdString);
-  links.forEach(link => {
-    const hrefRegex = /href=["']([^"']+)["']/i;
-    const datalinkRegex =  /data-internal-anchor=["']([^"']+)["']/i;
-    const datalinkMatch = datalinkRegex.exec(link.html);
-
-
-    if (datalinkMatch) {
-      // datalinkmatch ../5 Operating Instructions#How to create a custom Oskari Server Extension"
-      // where ../<directory>#<first heading text In the file being referred>
-      // TODO: this syntax / mechanism is plain horror for someone trying to maintain these manually in source docs.
-      // We need to come up with better solution but leaving this to simmer for now.
-      const datalinkRef = datalinkMatch[1];
-      const parsedHref = parseRef(datalinkRef);
-      const newLinkHtml = link.html.replace(hrefRegex, `href="${parsedHref}"`);
-      mdString = mdString.replace(link.html, newLinkHtml);
-    }
-  });
-
-  return mdString;
-}
-
-const parseRef = (ref: string): string => {
-  //1) split at #
-  //2) if startswith ../ add that manually
-  //3) final link ../ + slugify(datalinkSplit[0]) + '#' + slugify(datalinkSplit[1])
-  const split = ref.split('#');
-  if (split.length === 2) {
-
-    const pathStart = ''; //split[0].startsWith('../') ? '../' : '';
-    const pathSlug = slugify(split[0].replace('../', ''));
-    const headerSlug = slugify(split[1]);
-    return pathStart + pathSlug + '#' + headerSlug;
-  }
-
-  return '#' + slugify(ref);
-}
-
-*/
-
-
 
 /**
  * Creates a slugified url for use in documentation section

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -2,7 +2,15 @@ import fs from 'fs'
 import path from 'path'
 import matter from 'gray-matter'
 import { mdToHtml } from './customMarked'
-import { insertIdsToHeaders, processAllLinks, processCodeBlocks, processHeaders, processInternalMDLinks, processMermaidCodeBlocks, processLanguageSpecificCodeBlocks, processMigrationGuideLinks, processTripleQuoteCodeBlocks, updateMarkdownHtmlStyleTags, updateMarkdownImagePaths } from './markdownToHtml'
+import {
+  insertIdsToHeaders,
+  processAllLinks,
+  processHeaders,
+  processInternalMDLinks,
+  processMigrationGuideLinks,
+  updateMarkdownHtmlStyleTags,
+  updateMarkdownImagePaths
+} from './markdownToHtml'
 import { MarkdownFileMetadata, VersionDocType } from '@/types/types'
 
 function compileMarkdownToHTML(markdown: string, startingSectionNumber: string): {
@@ -100,16 +108,6 @@ const processMarkdown = (markdown: string, imagesPath: string, indexJSON: Markdo
 
   //process rest of the links from md style -> <a href... to help the lib that's supposed to be doing this in its efforts.
   markdown = processAllLinks(markdown);
-
-  // these are dependent to be run in this order
-  markdown = processMermaidCodeBlocks(markdown);
-  markdown = processLanguageSpecificCodeBlocks(markdown, 'javascript');
-  markdown = processLanguageSpecificCodeBlocks(markdown, 'java');
-  markdown = processLanguageSpecificCodeBlocks(markdown, 'sql');
-  markdown = processLanguageSpecificCodeBlocks(markdown, 'json');
-
-  markdown = processTripleQuoteCodeBlocks(markdown);
-  markdown = processCodeBlocks(markdown);
   return markdown;
 }
 


### PR DESCRIPTION
add a hook for codeblocks in marked renderer and get rid of our custom regex find n' replace -stuff...

![image](https://github.com/user-attachments/assets/cf3ce151-e9c7-42e9-b246-44abf85099ae)
