### PR TITLE
strip file extension from blogposts' et al slug

### DIFF
--- a/scripts/generateContentMetadata.js
+++ b/scripts/generateContentMetadata.js
@@ -26,7 +26,7 @@ function listFilesRecursively(baseRelativePath, fileRelativePath, resourcesRunti
                     data = replaceImagePaths(data, content, resourcesRuntimePath);
                 }
 
-                const slug = slugify(pathForSlug + file);
+                const slug = slugify(pathForSlug + path.parse(file).name);
                 const fileData = {
                     ...data,
                     path: newRelativePath,


### PR DESCRIPTION
strip the .md extension from slug toreduce the stupidity of links