### PR TITLE
Jetty 9 replaced with Tomcat 10.1 on the download zip

### DIFF
--- a/app/download/page.tsx
+++ b/app/download/page.tsx
@@ -43,7 +43,7 @@ export default async function DownloadPage() {
         <IconCard
           className='!bg-[var(--color-accent)]'
           title='Latest version'
-          subtitle='A Jetty 9 package of Oskari. Recommended for preview use.'
+          subtitle='A Tomcat 10.1 package of Oskari. Recommended for preview use.'
           content={
             <>
               <div className='flex justify-center'>


### PR DESCRIPTION
Looks like other references are on the oskari-documentation repo