### PR TITLE
Heading numberings revised

### DIFF
--- a/app/documentation/docs/[version]/[slug]/AccordionListWrapper.tsx
+++ b/app/documentation/docs/[version]/[slug]/AccordionListWrapper.tsx
@@ -6,12 +6,16 @@ import { useState } from 'react';
 import Link from 'next/link';
 import { cleanTags } from '@/lib/utils';
 
+export const DEFAULT_NAVIGATION_MAXDEPTH = 3;
+
 export default function AccordionListWrapper({
   items,
-  initialOpenSection
+  initialOpenSection,
+  navigationMaxDepth = DEFAULT_NAVIGATION_MAXDEPTH
 }: {
   items: MarkdownFileMetadata[] | null,
-  initialOpenSection: string
+  initialOpenSection: string,
+  navigationMaxDepth?: number
 }) {
 
   const [openSection, setOpenSection] = useState(initialOpenSection);
@@ -20,7 +24,7 @@ export default function AccordionListWrapper({
   ) => {
     return (
       <ul className={styles.accordionMenu}>
-        {items?.filter(item => parseInt(item.level) <= 3)
+        {items?.filter(item => parseInt(item.level) <= navigationMaxDepth)
         .map((item, index) => (
           <li key={item.slug + '_' + index}>
             <Link

--- a/app/documentation/docs/[version]/[slug]/AccordionListWrapper.tsx
+++ b/app/documentation/docs/[version]/[slug]/AccordionListWrapper.tsx
@@ -20,7 +20,8 @@ export default function AccordionListWrapper({
   ) => {
     return (
       <ul className={styles.accordionMenu}>
-        {items?.map((item, index) => (
+        {items?.filter(item => parseInt(item.level) <= 3)
+        .map((item, index) => (
           <li key={item.slug + '_' + index}>
             <Link
               href={item.slug === parentSlug ? item.slug : parentSlug + '#' + item.slug}

--- a/app/documentation/docs/[version]/[slug]/page.tsx
+++ b/app/documentation/docs/[version]/[slug]/page.tsx
@@ -65,7 +65,10 @@ export default async function SingleDocPage({
     <div style={{ display: 'flex', flexDirection: 'column', gap: '2rem' }}>
       <VersionSidebar selectedVersion={version} versions={versions} baseHref='/documentation/docs/' />
       <AccordionGroup>
-        <AccordionListWrapper items={indexJSON[version]} initialOpenSection={activeSection.slug}/>
+        <AccordionListWrapper
+          items={indexJSON[version]}
+          initialOpenSection={activeSection.slug}
+          navigationMaxDepth={2}/>
       </AccordionGroup>
     </div>
     <div>

--- a/lib/customMarked.test.ts
+++ b/lib/customMarked.test.ts
@@ -1,0 +1,169 @@
+import slugify from 'slugify'
+import { BADGE_TEMPLATES, mdToHtml } from './customMarked'
+
+const createTestMd = () => {
+  const originals = []
+  const expecteds = []
+  for (let first = 1; first < 4; first++) {
+    originals.push('# ' + first + '\r\n')
+    expecteds.push(
+      '<h1 id="' + first + '">' + first + ' ' + first + '</h1>\r\n'
+    )
+    for (let second = 1; second < 4; second++) {
+      const joinedSecond = [first, second].join('.')
+      originals.push('## ' + joinedSecond + '\r\n')
+      expecteds.push(
+        '<h2 id="' +
+          joinedSecond +
+          '">' +
+          joinedSecond +
+          ' ' +
+          joinedSecond +
+          '</h2>\r\n'
+      )
+      for (let third = 1; third < 4; third++) {
+        const joinedThird = [first, second, third].join('.')
+        originals.push('### ' + joinedThird + '\r\n')
+        expecteds.push(
+          '<h3 id="' +
+            joinedThird +
+            '">' +
+            joinedThird +
+            ' ' +
+            joinedThird +
+            '</h3>\r\n'
+        )
+      }
+    }
+  }
+
+  return {
+    originals,
+    expecteds,
+  }
+}
+
+describe('mdToHTML tests', () => {
+  describe('test rendering headings', () => {
+    it('should prefix heading with "1" and have the slug as id', () => {
+      const h1Content = 'FUU FUU FUU FUU'
+      const h1ExpectedContent = '1 FUU'
+      const h1ExpectedId = 'id="' + slugify(h1Content) + '"'
+      const originalMd = '# ' + h1Content
+
+      const processedHTML = mdToHtml(originalMd, true, '1')
+      expect(processedHTML?.html?.indexOf(h1ExpectedContent)).toBeGreaterThan(
+        -1
+      )
+      expect(processedHTML?.html?.indexOf(h1ExpectedId)).toBeGreaterThan(-1)
+    })
+
+    it("should handle headings' semantic numbering", () => {
+      const generated = createTestMd()
+      // <div><h1>1</h1><h2>1.1</h2>.....
+      const originalMd = generated.originals.join('')
+      // <div><h1 id="1">1 1</h1><h2 id="1.1">1.1 1.1</h2>....
+      const expectedHtml = generated.expecteds.join('')
+
+      //      console.log(originalMd);
+      //      console.log(expectedHtml);
+      const processedHTML = mdToHtml(originalMd, true, '1').html
+      expect(processedHTML).toEqual(expectedHtml)
+    })
+
+    it('should NOT allow zeros in semantic numbering (case skipping heading levels)', () => {
+      const h1 = '# FUU\r\n'
+      const h3 = '### FUU\r\n'
+      const processed = mdToHtml(h1 + h3, true, '1').html
+      expect(processed.indexOf('1.0.1')).toBe(-1)
+      expect(processed.indexOf('1.1.1')).toBeGreaterThan(-1)
+    })
+
+    it('should be capapble of handling very many levels of headings', () => {
+      const h1 = '# FUU\r\n'
+      const h2 = '## FUU\r\n'
+      const h3 = '### FUU\r\n'
+      const h4 = '#### FUU\r\n'
+      const h5 = '##### FUU\r\n'
+      const h6 = '###### FUU\r\n'
+
+      const expectedH1 = '<h1 id="FUU">FUU</h1>\r\n'
+      const expectedH2 = '<h2 id="FUU">FUU</h2>\r\n'
+      const expectedH3 = '<h3 id="FUU">FUU</h3>\r\n'
+      const expectedH4 = '<h4 id="FUU">FUU</h4>\r\n'
+      const expectedH5 = '<h5 id="FUU">FUU</h5>\r\n'
+      const expectedH6 = '<h6 id="FUU">FUU</h6>\r\n'
+
+      expect(mdToHtml(h1, false).html).toBe(expectedH1)
+      expect(mdToHtml(h2, false).html).toBe(expectedH2)
+      expect(mdToHtml(h3, false).html).toBe(expectedH3)
+      expect(mdToHtml(h4, false).html).toBe(expectedH4)
+      expect(mdToHtml(h5, false).html).toBe(expectedH5)
+      expect(mdToHtml(h6, false).html).toBe(expectedH6)
+    })
+
+    it('should keep headings with no tags unchanged', () => {
+      const h1 = '# FUU'
+      const expectedh1 = '<h1 id="FUU">FUU</h1>'
+      const h2 = '## FUU2'
+      const expectedh2 = '<h2 id="FUU2">FUU2</h2>'
+      const h3 = '### FUU3'
+      const expectedh3 = '<h3 id="FUU3">FUU3</h3>'
+
+      expect(mdToHtml(h1, false).html.indexOf(expectedh1)).toBe(0)
+      expect(mdToHtml(h2, false).html.indexOf(expectedh2)).toBe(0)
+      expect(mdToHtml(h3, false).html.indexOf(expectedh3)).toBe(0)
+    })
+
+    it('should be able to recognize given tags', () => {
+      const h1 = '# [rpc] FUU'
+      const expectedh1 = '<h1 id="FUU">FUU' + BADGE_TEMPLATES['[rpc]'] + '</h1>'
+      const h2 = '## [add] FUU2'
+      const expectedh2 =
+        '<h2 id="FUU2">FUU2' + BADGE_TEMPLATES['[add]'] + '</h2>'
+      const h3 = '### [rem] FUU3'
+      const expectedh3 =
+        '<h3 id="FUU3">FUU3' + BADGE_TEMPLATES['[rem]'] + '</h3>'
+      const h4 = '#### [mod] FUU4'
+      const expectedh4 =
+        '<h4 id="FUU4">FUU4' + BADGE_TEMPLATES['[mod]'] + '</h4>'
+      const h5 = '##### [breaking] FUU5'
+      const expectedh5 =
+        '<h5 id="FUU5">FUU5' + BADGE_TEMPLATES['[breaking]'] + '</h5>'
+
+      expect(mdToHtml(h1, false).html.indexOf(expectedh1)).toBe(0)
+      expect(mdToHtml(h2, false).html.indexOf(expectedh2)).toBe(0)
+      expect(mdToHtml(h3, false).html.indexOf(expectedh3)).toBe(0)
+      expect(mdToHtml(h4, false).html.indexOf(expectedh4)).toBe(0)
+      expect(mdToHtml(h5, false).html.indexOf(expectedh5)).toBe(0)
+    })
+
+    it('should handle multiple tags per heading', () => {
+      const h1 = '# [rem][add][mod][breaking][rpc] FUU'
+
+      const processed = mdToHtml(h1, false).html
+      expect(processed.indexOf('[add]')).toBe(-1)
+      expect(processed.indexOf('[mod]')).toBe(-1)
+      expect(processed.indexOf('[rem]')).toBe(-1)
+      expect(processed.indexOf('[rpc]')).toBe(-1)
+      expect(processed.indexOf('[breaking]')).toBe(-1)
+
+      expect(processed.indexOf(BADGE_TEMPLATES['[add]'])).toBeGreaterThan(-1)
+      expect(processed.indexOf(BADGE_TEMPLATES['[mod]'])).toBeGreaterThan(-1)
+      expect(processed.indexOf(BADGE_TEMPLATES['[rem]'])).toBeGreaterThan(-1)
+      expect(processed.indexOf(BADGE_TEMPLATES['[rpc]'])).toBeGreaterThan(-1)
+      expect(processed.indexOf(BADGE_TEMPLATES['[breaking]'])).toBeGreaterThan(
+        -1
+      )
+    })
+
+    it('should add \r\n after a heading to avoid problems resulting from a "missing" paragraph', () => {
+      const h1 = '# FUU'
+      const expectedh1 = '<h1 id="FUU">FUU</h1>'
+      const expectedSuffix = '\r\n'
+      const processed = mdToHtml(h1, false).html
+      expect(processed).toContain(expectedh1)
+      expect(processed).toContain(expectedSuffix)
+    })
+  })
+})

--- a/lib/customMarked.ts
+++ b/lib/customMarked.ts
@@ -42,14 +42,15 @@ const createRenderer = (useSectionNumbering: boolean, startingSectionNumber: str
             }
         }
         previousLevel = intLevel;
-        const slug = slugify(content)
-        const sectionNumber = sectionCounter.slice(0, level).map(sectionNumber => sectionNumber || 1).join('.');
-
-        const sectionNumberContent = useSectionNumbering ? sectionNumber : '';
-        anchorLinks.push({ level: level.toString(), content, slug, sectionNumber });
 
         const tags = content.match(tagRegex);
-        let cleanTitle = content.replace(tagRegex, '');
+        let cleanTitle = content.replace(tagRegex, '').trim();
+
+        const slug = slugify(cleanTitle)
+        const sectionNumber = sectionCounter.slice(0, level).map(sectionNumber => sectionNumber || 1).join('.');
+
+        const sectionNumberContent = useSectionNumbering ? sectionNumber + ' ' : '';
+        anchorLinks.push({ level: level.toString(), content, slug, sectionNumber });
 
         if (tags && tags.length > 0) {
           const badges = tags.map((tag: string) => {
@@ -59,9 +60,9 @@ const createRenderer = (useSectionNumbering: boolean, startingSectionNumber: str
             return null;
           }).filter((badge: string | null) => !!badge);
 
-          cleanTitle = `<h${level} id="${slug}">${sectionNumberContent} ${cleanTitle}${badges.join(' ')}</h${level}>`;
+          cleanTitle = `<h${level} id="${slug}">${sectionNumberContent}${cleanTitle}${badges.join(' ')}</h${level}>`;
         } else {
-          cleanTitle = `<h${level} id="${slug}">${sectionNumberContent} ${cleanTitle}</h${level}>`;
+          cleanTitle = `<h${level} id="${slug}">${sectionNumberContent}${cleanTitle}</h${level}>`;
         }
 
         // additional \r\n needs to be added cos marked is failing in a load of ways,

--- a/lib/customMarked.ts
+++ b/lib/customMarked.ts
@@ -1,25 +1,86 @@
 import { marked } from 'marked'
 import hljs from 'highlight.js';
 import 'highlight.js/scss/a11y-dark.scss';
+import slugify from 'slugify';
+import { DocAnchorLinksType } from '@/types/types';
 
 marked.use({
     gfm: true,
-  })
+})
 
 export const MERMAID_SNIPPET = '<pre class="mermaid">'
-
-// Just a wrapper for marker renderer so we could tune how different html-tags are processed
-// but most of the special handling is in markdownToHtml.ts
-const renderer = new marked.Renderer();
-
-renderer.code = (code: string, infostring?: string): string => {
-  if (infostring && infostring === 'mermaid') {
-    return `<pre class="mermaid">${code}</pre>`;
-  } else if (infostring) {
-    return `<pre><code class="language-${infostring} hljs">${hljs.highlightAuto(code).value}</code></pre>`;
-  }
-
-  return `<pre><code>${code}</code></pre>`;
+const tagRegex = /\[(.*?)\]/g;
+export const BADGE_TEMPLATES: {[key: string]: string} = {
+    '[add]': '<span class="label label-primary add" title="Added"><i class="fa-solid fa-plus"></i></span>',
+    '[mod]': '<span class="label label-primary mod" title="Modified"><i class="fa-solid fa-pen"></i></span>',
+    '[rem]': '<span class="label label-primary rem" title="Removed"><i class="fa-solid fa-trash-can"></i></span>',
+    '[breaking]': '<span class="label label-primary breaking" title="Breaking change. Not backwards compatible."><i class="fa-solid fa-triangle-exclamation"></i></span>',
+    '[rpc]': '<span class="label label-primary rpc" title="Available via RPC">RPC</span>',
 };
 
-export const mdToHtml = (src: string) => marked(src, { renderer: renderer })
+const createRenderer = (useSectionNumbering: boolean, startingSectionNumber: string, anchorLinks: Array<DocAnchorLinksType>) => {
+    const renderer = new marked.Renderer();
+    const sectionCounter = [parseInt(startingSectionNumber) - 1, 0, 0, 0, 0, 0];
+    let previousLevel = parseInt(startingSectionNumber) - 1;
+
+    renderer.code = (code: string, infostring?: string): string => {
+        if (infostring && infostring === 'mermaid') {
+          return `<pre class="mermaid">${code}</pre>`;
+        } else if (infostring) {
+          return `<pre><code class="language-${infostring} hljs">${hljs.highlightAuto(code).value}</code></pre>`;
+        }
+
+        return `<pre><code>${code}</code></pre>`;
+    };
+
+    renderer.heading = (content, level): string => {
+        const intLevel = level;
+        sectionCounter[intLevel - 1]++;
+        if (intLevel < previousLevel) {
+            for (let i = intLevel; i < sectionCounter.length; i++) {
+                sectionCounter[i] = 0;
+            }
+        }
+        previousLevel = intLevel;
+        const slug = slugify(content)
+        const sectionNumber = sectionCounter.slice(0, level).map(sectionNumber => sectionNumber || 1).join('.');
+
+        const sectionNumberContent = useSectionNumbering ? sectionNumber : '';
+        anchorLinks.push({ level: level.toString(), content, slug, sectionNumber });
+
+        const tags = content.match(tagRegex);
+        let cleanTitle = content.replace(tagRegex, '');
+
+        if (tags && tags.length > 0) {
+          const badges = tags.map((tag: string) => {
+            if (!!BADGE_TEMPLATES[tag.toLowerCase()]) {
+              return BADGE_TEMPLATES[tag.toLowerCase()];
+            }
+            return null;
+          }).filter((badge: string | null) => !!badge);
+
+          cleanTitle = `<h${level} id="${slug}">${sectionNumberContent} ${cleanTitle}${badges.join(' ')}</h${level}>`;
+        } else {
+          cleanTitle = `<h${level} id="${slug}">${sectionNumberContent} ${cleanTitle}</h${level}>`;
+        }
+
+        // additional \r\n needs to be added cos marked is failing in a load of ways,
+        // when the first element after heading is a link or a list or whatnot and this is missing in source.
+        return cleanTitle + '\r\n';
+    }
+
+    return renderer;
+}
+
+
+export const mdToHtml = (src: string, useSectionNumbering: boolean = false, startingSectionNumber: string = '1') => {
+    // Just a wrapper for marker renderer so we could tune how different html-tags are processed
+    // but most of the special handling is in markdownToHtml.ts
+    const anchorLinks: Array<DocAnchorLinksType> = [];
+    const renderer = createRenderer(useSectionNumbering, startingSectionNumber, anchorLinks);
+    const html = marked(src, { renderer: renderer });
+    return {
+        html,
+        anchorLinks
+    }
+};

--- a/lib/markdownToHtml.test.ts
+++ b/lib/markdownToHtml.test.ts
@@ -1,289 +1,141 @@
 
-import { BADGE_TEMPLATES, mdToHtml } from "./customMarked";
 import { processAllLinks, processInternalMDLinks, processMigrationGuideLinks, updateMarkdownHtmlStyleTags, updateMarkdownImagePaths } from "./markdownToHtml";
 
-import slugify from 'slugify';
+describe('update markdown image paths', () => {
+  it('should replace md image path with given runtime path', () => {
+    const originalPath = 'stuff/things/etc/common/';
+    const originalMd = '![FUU]('+originalPath+'image.png)';
+    const runtimePath = '/assets/docs/images'
+    const expected = '![FUU](' + runtimePath + '/' + originalPath + 'image.png)';
+    const processed = updateMarkdownImagePaths(originalMd, runtimePath);
+    expect(processed).toEqual(expected);
+  });
 
-const createTestMd = () => {
-  const originals = [];
-  const expecteds = [];
-  for (let first = 1; first < 4; first++) {
-    originals.push('# ' + first + '\r\n')
-    expecteds.push('<h1 id="'+first+'">' + first + ' ' + first + '</h1>\r\n')
-    for (let second = 1; second < 4; second++) {
-      const joinedSecond = [first, second].join('.');
-      originals.push('## ' + joinedSecond + '\r\n')
-      expecteds.push('<h2 id="' + joinedSecond + '">' + joinedSecond + ' ' + joinedSecond + '</h2>\r\n')
-      for (let third = 1; third < 4; third++) {
-        const joinedThird = [first, second, third].join('.');
-        originals.push('### ' + joinedThird + '\r\n')
-        expecteds.push('<h3 id="' + joinedThird + '">' + joinedThird + ' ' + joinedThird + '</h3>\r\n')
-      }
+  it('should replace reserved keyword \'resources\' from original path (case documentation)', () => {
+    const originalPath = '/resources/images/backend/';
+    const originalMd = '![FUU]('+originalPath+'image.png)';
+    const runtimePath = '/assets/docs/2.13.0/resources/'
+    const expected = '![FUU](' + runtimePath + 'images/backend/image.png)';
+    const processed = updateMarkdownImagePaths(originalMd, runtimePath);
+    expect(processed).toEqual(expected);
+  });
+});
+
+describe('replace html style tags', () => {
+  it ('should replace < and > with {{ and }} for content inside quotation marks', () => {
+    const tagged = '"<fuu>"';
+    const expected = '"{{fuu}}"';
+    expect(updateMarkdownHtmlStyleTags(tagged)).toEqual(expected);
+  });
+
+  it ('should leave < and > unharmed when NOT inside quotation marks', () => {
+    const tagged = '<fuu>';
+    expect(updateMarkdownHtmlStyleTags(tagged)).toEqual(tagged);
+  });
+});
+
+describe('Link to migration guide', () => {
+  it('should replace migration guide link with anchor', () => {
+    const markdown = `[Migrationguide](MigrationGuide.md)`;
+    const markdownAfter = `<a href="#Migration-guide">Migrationguide</a>`;
+    const processed = processMigrationGuideLinks(markdown).trim();
+    expect(processed).toEqual(markdownAfter);
+  });
+
+  it('should leave link with absolute path alone', () => {
+    const markdown = `[Migrationguide](http://www.migrationguideland.com/MigrationGuide.md)`;
+    const processed = processMigrationGuideLinks(markdown).trim();
+    expect(processed).toEqual(markdown);
+  });
+})
+
+describe('Rest of the links', () => {
+  it('should replace md-style link with anchor', () => {
+    const markdown = `[Some link text](http://somelink.com)`;
+    const markdownAfter = `<a href="http://somelink.com">Some link text</a>`;
+    const processed = processAllLinks(markdown).trim();
+    expect(processed).toEqual(markdownAfter);
+  });
+
+  it('should leave imagelink alone', () => {
+    const markdown = `![Some image](http://someimage.com)`;
+    const processed = processAllLinks(markdown).trim();
+    expect(processed).toEqual(markdown);
+  });
+})
+
+describe("processInternalMDLinks", function() {
+  // eslint-disable-next-line  @typescript-eslint/no-explicit-any
+  const indexJSON: any[] = [
+    {
+      "slug": "section-one",
+      "title": "Section One",
+      "children": [
+        {
+          "fileName": "file1.md",
+          "anchor": "anchor1"
+        },
+        {
+          "fileName": "file2.md",
+          "anchor": "anchor2"
+        }
+      ]
+    },
+    {
+      "slug": "section-two",
+      "title": "Section Two",
+      "children": [
+        {
+          "fileName": "file3.md",
+          "anchor": "anchor3"
+        },
+        {
+          "fileName": "file4.md",
+          "anchor": "anchor4"
+        }
+      ]
     }
-  }
+  ];
 
-  return {
-    originals,
-    expecteds
-  }
-}
-
-
-describe('mdToHTML tests', () => {
-  describe('insert ids to headers tests', () => {
-    it('should prefix heading with "1" and have the slug as id', () => {
-      const h1Content = 'FUU FUU FUU FUU';
-      const h1ExpectedContent = '1 FUU';
-      const h1ExpectedId = 'id="'+slugify(h1Content)+'"';
-      const originalMd = '# '+h1Content;
-
-      const processedHTML = mdToHtml(originalMd, true, '1');
-      expect(processedHTML?.html?.indexOf(h1ExpectedContent)).toBeGreaterThan(-1);
-      expect(processedHTML?.html?.indexOf(h1ExpectedId)).toBeGreaterThan(-1);
-    });
-
-    it('should handle headings\' semantic numbering', () => {
-
-      const generated = createTestMd();
-      // <div><h1>1</h1><h2>1.1</h2>.....
-      const originalMd = generated.originals.join('');
-      // <div><h1 id="1">1 1</h1><h2 id="1.1">1.1 1.1</h2>....
-      const expectedHtml = generated.expecteds.join('');
-
-//      console.log(originalMd);
-//      console.log(expectedHtml);
-      const processedHTML = mdToHtml(originalMd, true, '1').html;
-      expect(processedHTML).toEqual(expectedHtml);
-    });
-
-    it('should NOT allow zeros in semantic numbering (case skipping heading levels)', () => {
-      const h1 = '# FUU\r\n';
-      const h3 = '### FUU\r\n';
-      const processed = mdToHtml(h1 + h3, true, '1').html;
-      expect(processed.indexOf('1.0.1')).toBe(-1);
-      expect(processed.indexOf('1.1.1')).toBeGreaterThan(-1);
-    })
-
-    it('should be capapble of handling very many levels of headings', () => {
-      const h1 = '# FUU\r\n';
-      const h2 = '## FUU\r\n';
-      const h3 = '### FUU\r\n';
-      const h4 = '#### FUU\r\n';
-      const h5 = '##### FUU\r\n';
-      const h6 = '###### FUU\r\n';
-
-      const expectedH1 = '<h1 id="FUU">FUU</h1>\r\n';
-      const expectedH2 = '<h2 id="FUU">FUU</h2>\r\n';
-      const expectedH3 = '<h3 id="FUU">FUU</h3>\r\n';
-      const expectedH4 = '<h4 id="FUU">FUU</h4>\r\n';
-      const expectedH5 = '<h5 id="FUU">FUU</h5>\r\n';
-      const expectedH6 = '<h6 id="FUU">FUU</h6>\r\n';
-
-      expect(mdToHtml(h1, false).html).toBe(expectedH1);
-      expect(mdToHtml(h2, false).html).toBe(expectedH2);
-      expect(mdToHtml(h3, false).html).toBe(expectedH3);
-      expect(mdToHtml(h4, false).html).toBe(expectedH4);
-      expect(mdToHtml(h5, false).html).toBe(expectedH5);
-      expect(mdToHtml(h6, false).html).toBe(expectedH6);
-    })
+  it("replaces a relative link with the correct link from indexJSON", function() {
+    const markdownContent = "Check this [link](file1.md) in the content.";
+    const activeSectionTitle = "Section One";
+    const result = processInternalMDLinks(markdownContent, indexJSON, activeSectionTitle);
+    expect(result).toBe("Check this [link](section-one#anchor1) in the content.");
   });
 
-  describe('update markdown image paths', () => {
-    it('should replace md image path with given runtime path', () => {
-      const originalPath = 'stuff/things/etc/common/';
-      const originalMd = '![FUU]('+originalPath+'image.png)';
-      const runtimePath = '/assets/docs/images'
-      const expected = '![FUU](' + runtimePath + '/' + originalPath + 'image.png)';
-      const processed = updateMarkdownImagePaths(originalMd, runtimePath);
-      expect(processed).toEqual(expected);
-    });
-
-    it('should replace reserved keyword \'resources\' from original path (case documentation)', () => {
-      const originalPath = '/resources/images/backend/';
-      const originalMd = '![FUU]('+originalPath+'image.png)';
-      const runtimePath = '/assets/docs/2.13.0/resources/'
-      const expected = '![FUU](' + runtimePath + 'images/backend/image.png)';
-      const processed = updateMarkdownImagePaths(originalMd, runtimePath);
-      expect(processed).toEqual(expected);
-    });
+  it("does not replace external links", function() {
+    const markdownContent = "Visit [Google](https://www.google.com) for more info.";
+    const activeSectionTitle = "Section One";
+    const result = processInternalMDLinks(markdownContent, indexJSON, activeSectionTitle);
+    expect(result).toBe("Visit [Google](https://www.google.com) for more info.");
   });
 
-  describe('replace html style tags', () => {
-    it ('should replace < and > with {{ and }} for content inside quotation marks', () => {
-      const tagged = '"<fuu>"';
-      const expected = '"{{fuu}}"';
-      expect(updateMarkdownHtmlStyleTags(tagged)).toEqual(expected);
-    });
-
-    it ('should leave < and > unharmed when NOT inside quotation marks', () => {
-      const tagged = '<fuu>';
-      expect(updateMarkdownHtmlStyleTags(tagged)).toEqual(tagged);
-    });
+  it("replaces a relative link with a path and correct link from indexJSON", function() {
+    const markdownContent = "More info [here](../Section Two/file3.md).";
+    const activeSectionTitle = "Section One";
+    const result = processInternalMDLinks(markdownContent, indexJSON, activeSectionTitle);
+    expect(result).toBe("More info [here](section-two#anchor3).");
   });
 
-  describe('processing headers', () => {
-    it ('should keep headings with no tags unchanged', () => {
-      const h1 = '# FUU';
-      const expectedh1 = '<h1 id="FUU">FUU</h1>';
-      const h2 = '## FUU2';
-      const expectedh2 = '<h2 id="FUU2">FUU2</h2>';
-      const h3 = '### FUU3';
-      const expectedh3 = '<h3 id="FUU3">FUU3</h3>';
-
-      expect(mdToHtml(h1, false).html.indexOf(expectedh1)).toBe(0);
-      expect(mdToHtml(h2, false).html.indexOf(expectedh2)).toBe(0);
-      expect(mdToHtml(h3, false).html.indexOf(expectedh3)).toBe(0);
-    });
-
-    it ('should be able to recognize given tags', () => {
-      const h1 = '# [rpc] FUU';
-      const expectedh1 = '<h1 id="FUU">FUU' + BADGE_TEMPLATES['[rpc]'] + '</h1>';
-      const h2 = '## [add] FUU2';
-      const expectedh2 = '<h2 id="FUU2">FUU2' + BADGE_TEMPLATES['[add]'] + '</h2>';
-      const h3 = '### [rem] FUU3';
-      const expectedh3 = '<h3 id="FUU3">FUU3' + BADGE_TEMPLATES['[rem]'] + '</h3>';
-      const h4 = '#### [mod] FUU4';
-      const expectedh4 = '<h4 id="FUU4">FUU4' + BADGE_TEMPLATES['[mod]'] + '</h4>';
-      const h5 = '##### [breaking] FUU5';
-      const expectedh5 = '<h5 id="FUU5">FUU5' + BADGE_TEMPLATES['[breaking]'] + '</h5>';
-
-      expect(mdToHtml(h1, false).html.indexOf(expectedh1)).toBe(0);
-      expect(mdToHtml(h2, false).html.indexOf(expectedh2)).toBe(0);
-      expect(mdToHtml(h3, false).html.indexOf(expectedh3)).toBe(0);
-      expect(mdToHtml(h4, false).html.indexOf(expectedh4)).toBe(0);
-      expect(mdToHtml(h5, false).html.indexOf(expectedh5)).toBe(0);
-    });
-
-    it ('should handle multiple tags per heading', () => {
-      const h1 = '# [rem][add][mod][breaking][rpc] FUU';
-
-      const processed = mdToHtml(h1, false).html;
-      expect(processed.indexOf('[add]')).toBe(-1);
-      expect(processed.indexOf('[mod]')).toBe(-1);
-      expect(processed.indexOf('[rem]')).toBe(-1);
-      expect(processed.indexOf('[rpc]')).toBe(-1);
-      expect(processed.indexOf('[breaking]')).toBe(-1);
-
-      expect(processed.indexOf(BADGE_TEMPLATES['[add]'])).toBeGreaterThan(-1);
-      expect(processed.indexOf(BADGE_TEMPLATES['[mod]'])).toBeGreaterThan(-1);
-      expect(processed.indexOf(BADGE_TEMPLATES['[rem]'])).toBeGreaterThan(-1);
-      expect(processed.indexOf(BADGE_TEMPLATES['[rpc]'])).toBeGreaterThan(-1);
-      expect(processed.indexOf(BADGE_TEMPLATES['[breaking]'])).toBeGreaterThan(-1);
-    });
-
-    it('should add \r\n after a heading to avoid problems resulting from a "missing" paragraph', () => {
-      const h1 = '# FUU';
-      const expectedh1 = '<h1 id="FUU">FUU</h1>';
-      const expectedSuffix = '\r\n';
-      const processed = mdToHtml(h1, false).html;
-      expect(processed).toContain(expectedh1);
-      expect(processed).toContain(expectedSuffix);
-    })
+  it("does not replace a link if no matching file is found in indexJSON", function() {
+    const markdownContent = "Check this [link](nonexistent.md) in the content.";
+    const activeSectionTitle = "Section One";
+    const result = processInternalMDLinks(markdownContent, indexJSON, activeSectionTitle);
+    expect(result).toBe("Check this [link](nonexistent.md) in the content.");
   });
 
-  describe('Link to migration guide', () => {
-    it('should replace migration guide link with anchor', () => {
-      const markdown = `[Migrationguide](MigrationGuide.md)`;
-      const markdownAfter = `<a href="#Migration-guide">Migrationguide</a>`;
-      const processed = processMigrationGuideLinks(markdown).trim();
-      expect(processed).toEqual(markdownAfter);
-    });
+  it("handles multiple links in the same content", function() {
+    const markdownContent = "Links: [file1](file1.md), [file4](../Section Two/file4.md), and [external](https://www.example.com).";
+    const activeSectionTitle = "Section One";
+    const result = processInternalMDLinks(markdownContent, indexJSON, activeSectionTitle);
+    expect(result).toBe("Links: [file1](section-one#anchor1), [file4](section-two#anchor4), and [external](https://www.example.com).");
+  });
 
-    it('should leave link with absolute path alone', () => {
-      const markdown = `[Migrationguide](http://www.migrationguideland.com/MigrationGuide.md)`;
-      const processed = processMigrationGuideLinks(markdown).trim();
-      expect(processed).toEqual(markdown);
-    });
-  })
-
-  describe('Rest of the links', () => {
-    it('should replace md-style link with anchor', () => {
-      const markdown = `[Some link text](http://somelink.com)`;
-      const markdownAfter = `<a href="http://somelink.com">Some link text</a>`;
-      const processed = processAllLinks(markdown).trim();
-      expect(processed).toEqual(markdownAfter);
-    });
-
-    it('should leave imagelink alone', () => {
-      const markdown = `![Some image](http://someimage.com)`;
-      const processed = processAllLinks(markdown).trim();
-      expect(processed).toEqual(markdown);
-    });
-  })
-
-  describe("processInternalMDLinks", function() {
-    // eslint-disable-next-line  @typescript-eslint/no-explicit-any
-    const indexJSON: any[] = [
-      {
-        "slug": "section-one",
-        "title": "Section One",
-        "children": [
-          {
-            "fileName": "file1.md",
-            "anchor": "anchor1"
-          },
-          {
-            "fileName": "file2.md",
-            "anchor": "anchor2"
-          }
-        ]
-      },
-      {
-        "slug": "section-two",
-        "title": "Section Two",
-        "children": [
-          {
-            "fileName": "file3.md",
-            "anchor": "anchor3"
-          },
-          {
-            "fileName": "file4.md",
-            "anchor": "anchor4"
-          }
-        ]
-      }
-    ];
-
-    it("replaces a relative link with the correct link from indexJSON", function() {
-      const markdownContent = "Check this [link](file1.md) in the content.";
-      const activeSectionTitle = "Section One";
-      const result = processInternalMDLinks(markdownContent, indexJSON, activeSectionTitle);
-      expect(result).toBe("Check this [link](section-one#anchor1) in the content.");
-    });
-
-    it("does not replace external links", function() {
-      const markdownContent = "Visit [Google](https://www.google.com) for more info.";
-      const activeSectionTitle = "Section One";
-      const result = processInternalMDLinks(markdownContent, indexJSON, activeSectionTitle);
-      expect(result).toBe("Visit [Google](https://www.google.com) for more info.");
-    });
-
-    it("replaces a relative link with a path and correct link from indexJSON", function() {
-      const markdownContent = "More info [here](../Section Two/file3.md).";
-      const activeSectionTitle = "Section One";
-      const result = processInternalMDLinks(markdownContent, indexJSON, activeSectionTitle);
-      expect(result).toBe("More info [here](section-two#anchor3).");
-    });
-
-    it("does not replace a link if no matching file is found in indexJSON", function() {
-      const markdownContent = "Check this [link](nonexistent.md) in the content.";
-      const activeSectionTitle = "Section One";
-      const result = processInternalMDLinks(markdownContent, indexJSON, activeSectionTitle);
-      expect(result).toBe("Check this [link](nonexistent.md) in the content.");
-    });
-
-    it("handles multiple links in the same content", function() {
-      const markdownContent = "Links: [file1](file1.md), [file4](../Section Two/file4.md), and [external](https://www.example.com).";
-      const activeSectionTitle = "Section One";
-      const result = processInternalMDLinks(markdownContent, indexJSON, activeSectionTitle);
-      expect(result).toBe("Links: [file1](section-one#anchor1), [file4](section-two#anchor4), and [external](https://www.example.com).");
-    });
-
-    it("leaves content unchanged if there are no links", function() {
-      const markdownContent = "This content has no links.";
-      const activeSectionTitle = "Section One";
-      const result = processInternalMDLinks(markdownContent, indexJSON, activeSectionTitle);
-      expect(result).toBe("This content has no links.");
-    });
+  it("leaves content unchanged if there are no links", function() {
+    const markdownContent = "This content has no links.";
+    const activeSectionTitle = "Section One";
+    const result = processInternalMDLinks(markdownContent, indexJSON, activeSectionTitle);
+    expect(result).toBe("This content has no links.");
   });
 });

--- a/lib/markdownToHtml.ts
+++ b/lib/markdownToHtml.ts
@@ -1,4 +1,4 @@
-import { DocAnchorLinksType, MarkdownFileMetadata } from '@/types/types';
+import { MarkdownFileMetadata } from '@/types/types';
 import slugify from 'slugify';
 import 'highlight.js/scss/a11y-dark.scss';
 

--- a/lib/markdownToHtml.ts
+++ b/lib/markdownToHtml.ts
@@ -2,35 +2,6 @@ import { DocAnchorLinksType, MarkdownFileMetadata } from '@/types/types';
 import slugify from 'slugify';
 import 'highlight.js/scss/a11y-dark.scss';
 
-export const insertIdsToHeaders = (htmlString: string, startingSectionNumber: string) => {
-  const headerRegex = /<h([1-3])>(.*?)<\/h\1>/g
-  const anchorLinks: Array<DocAnchorLinksType> = []
-  const sectionCounter = [parseInt(startingSectionNumber) - 1, 0, 0, 0, 0, 0];
-  let previousLevel = parseInt(startingSectionNumber) - 1;
-
-  const newHtmlString = htmlString.replace(
-    headerRegex,
-    function (match: string, level: string, content: string) {
-      const intLevel = parseInt(level);
-      sectionCounter[intLevel - 1]++;
-      if (intLevel < previousLevel) {
-        for (let i = intLevel; i < sectionCounter.length; i++) {
-          sectionCounter[i] = 0;
-        }
-      }
-      previousLevel = intLevel;
-      const slug = slugify(content)
-      const sectionNumber = sectionCounter.slice(0, parseInt(level)).map(sectionNumber => sectionNumber || 1).join('.');
-      anchorLinks.push({ level, content, slug, sectionNumber });
-      return `<h${level} id="${slug}">${sectionNumber} ${content}</h${level}>`
-    }
-  )
-  return {
-    html: newHtmlString,
-    anchorLinks
-  }
-}
-
 export const updateMarkdownImagePaths = (markdownString: string, imagesRuntimePath: string = ''): string => {
   const regex = /!\[(.*?)\]\((.*?)\)/g;
 
@@ -60,55 +31,6 @@ export const updateMarkdownHtmlStyleTags = (markdownString: string): string => {
   const result = markdownString.replace(regex, replaceFunc);
 
   return result;
-}
-
-export const badgeTemplates: {[key: string]: string} = {
-  '[add]': '<span class="label label-primary add" title="Added"><i class="fa-solid fa-plus"></i></span>',
-  '[mod]': '<span class="label label-primary mod" title="Modified"><i class="fa-solid fa-pen"></i></span>',
-  '[rem]': '<span class="label label-primary rem" title="Removed"><i class="fa-solid fa-trash-can"></i></span>',
-  '[breaking]': '<span class="label label-primary breaking" title="Breaking change. Not backwards compatible."><i class="fa-solid fa-triangle-exclamation"></i></span>',
-  '[rpc]': '<span class="label label-primary rpc" title="Available via RPC">RPC</span>',
-};
-
-export const processHeaders = (markdownContent:string): string => {
-  const headerRegex = /^(#+)\s+(.*?)\s*$/gm;
-  const tagRegex = /\[(.*?)\]/g;
-  const codeBlockRegex = /(```[\s\S]*?```)/g;
-
-  // substitute codeblocks with placeholders to avoid # inside being changed into h1
-  const codeBlocks: string[] = [];
-  const withoutCodeBlocks = markdownContent.replace(codeBlockRegex, (match) => {
-    codeBlocks.push(match);
-    return `[[CODEBLOCK-${codeBlocks.length - 1}]]`;
-  });
-
-  const headingsReplaced = withoutCodeBlocks.replace(headerRegex, (match, hashes, title) => {
-    const tags = title.match(tagRegex);
-    let cleanTitle = title.replace(tagRegex, '');
-
-    if (tags) {
-      const badges: Array<string> = tags.map((tag: string) => {
-        if (!!badgeTemplates[tag.toLowerCase()]) {
-          return badgeTemplates[tag.toLowerCase()];
-        }
-        return null;
-      }).filter((badge: string) => !!badge);
-      cleanTitle = `<h${hashes.length}>${cleanTitle}${badges.join(' ')}</h${hashes.length}>`;
-    } else {
-      cleanTitle = `<h${hashes.length}>${cleanTitle}</h${hashes.length}>`;
-    }
-
-    // additional \r\n needs to be added cos marked is failing in a load of ways,
-    // when the first element after heading is a link or a list or whatnot and this is missing in source.
-    return cleanTitle + '\r\n';
-  });
-
-  // restore codeblocks
-  const processedContent = headingsReplaced.replace(/\[\[CODEBLOCK-(\d+)\]\]/g, (match, index) => {
-    return codeBlocks[index];
-  });
-
-  return processedContent;
 }
 
 export const processAllLinks = (markdownContent: string): string => {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -3,9 +3,7 @@ import path from 'path'
 import matter from 'gray-matter'
 import { mdToHtml } from './customMarked'
 import {
-  insertIdsToHeaders,
   processAllLinks,
-  processHeaders,
   processInternalMDLinks,
   processMigrationGuideLinks,
   updateMarkdownHtmlStyleTags,
@@ -18,12 +16,7 @@ function compileMarkdownToHTML(markdown: string, startingSectionNumber: string):
   anchorLinks: VersionDocType['anchorLinks']
 } {
   const { content } = matter(markdown)
-  const markedHtml = mdToHtml(content)
-  const { html, anchorLinks } = insertIdsToHeaders(markedHtml, startingSectionNumber)
-  return {
-    html,
-    anchorLinks,
-  }
+  return mdToHtml(content, true, startingSectionNumber);
 }
 export async function getVersionIndex(version: string, fetchHtmlContent: boolean = false) {
   const rootFolder = `_content/docs/${version}`;
@@ -94,9 +87,9 @@ const replaceLevelOneHeadingsWithLevelTwo = (markdown: string): string => {
 }
 
 const processMarkdown = (markdown: string, imagesPath: string, indexJSON: MarkdownFileMetadata[] = [], activeSectionTitle: string = '') => {
+
   markdown = updateMarkdownImagePaths(markdown, imagesPath);
   markdown = updateMarkdownHtmlStyleTags(markdown);
-  markdown = processHeaders(markdown);
   // migration guide first, specific treatment for that
   markdown = processMigrationGuideLinks(markdown);
 
@@ -114,5 +107,5 @@ const processMarkdown = (markdown: string, imagesPath: string, indexJSON: Markdo
 export const getMarkdownContentAsHtml = async function(mdFilePath: string, imagesFilePath: string) {
   const markdown = await readMarkdownFile(mdFilePath, imagesFilePath);
   const content = matter(markdown).content;
-  return mdToHtml(content);
+  return mdToHtml(content).html;
 }


### PR DESCRIPTION
Move headings' handling from custom script to markeds custom renderer and unite the processHeaders & insertIdsToHeaders - functions to one. 

-Allow numbering and id's for all level headings
-only show up to h3 in toc

![image](https://github.com/user-attachments/assets/049c8a51-952b-4cb7-a76f-3e26da767419)
