### PR TITLE
Decode '%20' etc to actual names when replacing the links in documentation

### DIFF
--- a/lib/markdownToHtml.test.ts
+++ b/lib/markdownToHtml.test.ts
@@ -118,6 +118,13 @@ describe("processInternalMDLinks", function() {
     expect(result).toBe("More info [here](section-two#anchor3).");
   });
 
+  it("replaces a relative encoded link with a path and correct link from indexJSON", function() {
+    const markdownContent = "More info [here](../Section%20Two/file3.md).";
+    const activeSectionTitle = "Section One";
+    const result = processInternalMDLinks(markdownContent, indexJSON, activeSectionTitle);
+    expect(result).toBe("More info [here](section-two#anchor3).");
+  });
+
   it("does not replace a link if no matching file is found in indexJSON", function() {
     const markdownContent = "Check this [link](nonexistent.md) in the content.";
     const activeSectionTitle = "Section One";

--- a/lib/markdownToHtml.ts
+++ b/lib/markdownToHtml.ts
@@ -66,7 +66,7 @@ const createSlugifiedUrlToAnchor = (url: string, indexJSON: MarkdownFileMetadata
   }
   const urlParts = url.split('/');
   const fileName = urlParts.pop();
-  const directory = urlParts.length > 0 ? urlParts.join('/') : '';
+  const directory = decodeURIComponent(urlParts.length > 0 ? urlParts.join('/') : '');
   const findChildAnchor = (children: MarkdownFileMetadata[], fileName: string) => {
     const child = children.find(child => child.fileName === fileName);
     return child ? child.anchor : null;


### PR DESCRIPTION
When doing the documentation for example VS code helps with links to other documentation but in the process also encodes the empty space characters in folder names with `%20`. This created broken links that can be fixed by decoding before trying to match them to actual folders.

Links that did not work without this are like this (from section 6): `[Frontend framework](../3%20Frontend%20framework/00030-Bundles.md)`