### PR TITLE
move img tag path manipulation to marked custom renderer

### DIFF
--- a/lib/customMarked.ts
+++ b/lib/customMarked.ts
@@ -18,7 +18,11 @@ export const BADGE_TEMPLATES: {[key: string]: string} = {
     '[rpc]': '<span class="label label-primary rpc" title="Available via RPC">RPC</span>',
 };
 
-const createRenderer = (useSectionNumbering: boolean, startingSectionNumber: string, anchorLinks: Array<DocAnchorLinksType>) => {
+const createRenderer = (
+  useSectionNumbering: boolean,
+  startingSectionNumber: string,
+  anchorLinks: Array<DocAnchorLinksType>,
+  imagesRuntimePath: string) => {
     const renderer = new marked.Renderer();
     const sectionCounter = [parseInt(startingSectionNumber) - 1, 0, 0, 0, 0, 0];
     let previousLevel = parseInt(startingSectionNumber) - 1;
@@ -70,15 +74,29 @@ const createRenderer = (useSectionNumbering: boolean, startingSectionNumber: str
         return cleanTitle + '\r\n';
     }
 
+    renderer.image = (href, title, text): string => {
+      if (imagesRuntimePath && imagesRuntimePath !== '') {
+        if (href.indexOf('resources') > -1) {
+          const pathStartRegex = /^.*?\/resources\//;
+          const replacedImagePath = href.replace(pathStartRegex, imagesRuntimePath);
+          return `<img src="${replacedImagePath}" alt="${text}"/>`;
+        }
+
+        return `<img src="${imagesRuntimePath + '/' + href}" alt="${text}"/>`;
+      }
+
+      return (`<img src=${href} alt=${text}/>`);
+    }
+
     return renderer;
 }
 
 
-export const mdToHtml = (src: string, useSectionNumbering: boolean = false, startingSectionNumber: string = '1') => {
+export const mdToHtml = (src: string, useSectionNumbering: boolean = false, startingSectionNumber: string = '1', imagesRuntimePath: string = '') => {
     // Just a wrapper for marker renderer so we could tune how different html-tags are processed
     // but most of the special handling is in markdownToHtml.ts
     const anchorLinks: Array<DocAnchorLinksType> = [];
-    const renderer = createRenderer(useSectionNumbering, startingSectionNumber, anchorLinks);
+    const renderer = createRenderer(useSectionNumbering, startingSectionNumber, anchorLinks, imagesRuntimePath);
     const html = marked(src, { renderer: renderer });
     return {
         html,

--- a/lib/markdownToHtml.ts
+++ b/lib/markdownToHtml.ts
@@ -2,24 +2,6 @@ import { MarkdownFileMetadata } from '@/types/types';
 import slugify from 'slugify';
 import 'highlight.js/scss/a11y-dark.scss';
 
-export const updateMarkdownImagePaths = (markdownString: string, imagesRuntimePath: string = ''): string => {
-  const regex = /!\[(.*?)\]\((.*?)\)/g;
-
-  function replaceFunc(match: string, altText: string, imagePath: string) {
-
-    if (match.indexOf('resources') > -1) {
-      const pathStartRegex = /^.*?\/resources\//;
-      const replacedImagePath = imagePath.replace(pathStartRegex, imagesRuntimePath);
-      return `![${altText}](${replacedImagePath})`;
-    }
-
-    return (`![${altText}](${imagesRuntimePath + '/' + imagePath})`);
-  }
-
-  const result = markdownString.replace(regex, replaceFunc);
-  return result;
-}
-
 export const updateMarkdownHtmlStyleTags = (markdownString: string): string => {
   const regex = /"([^"]*)"/g;
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -6,17 +6,16 @@ import {
   processAllLinks,
   processInternalMDLinks,
   processMigrationGuideLinks,
-  updateMarkdownHtmlStyleTags,
-  updateMarkdownImagePaths
+  updateMarkdownHtmlStyleTags
 } from './markdownToHtml'
 import { MarkdownFileMetadata, VersionDocType } from '@/types/types'
 
-function compileMarkdownToHTML(markdown: string, startingSectionNumber: string): {
+function compileMarkdownToHTML(markdown: string, startingSectionNumber: string, imagesPath: string): {
   html: string
   anchorLinks: VersionDocType['anchorLinks']
 } {
   const { content } = matter(markdown)
-  return mdToHtml(content, true, startingSectionNumber);
+  return mdToHtml(content, true, startingSectionNumber, imagesPath);
 }
 export async function getVersionIndex(version: string, fetchHtmlContent: boolean = false) {
   const rootFolder = `_content/docs/${version}`;
@@ -65,7 +64,7 @@ export const readAndConcatMarkdownFiles = async function(parentItem: MarkdownFil
 
   markdownAll = processMarkdown(markdownAll, imagesPath, indexJSON, activeSectionSlug);
 
-  const compiled = compileMarkdownToHTML(markdownAll, parentItem.ordinal || '1');
+  const compiled = compileMarkdownToHTML(markdownAll, parentItem.ordinal || '1', imagesPath);
   return compiled;
 };
 
@@ -88,7 +87,6 @@ const replaceLevelOneHeadingsWithLevelTwo = (markdown: string): string => {
 
 const processMarkdown = (markdown: string, imagesPath: string, indexJSON: MarkdownFileMetadata[] = [], activeSectionTitle: string = '') => {
 
-  markdown = updateMarkdownImagePaths(markdown, imagesPath);
   markdown = updateMarkdownHtmlStyleTags(markdown);
   // migration guide first, specific treatment for that
   markdown = processMigrationGuideLinks(markdown);
@@ -107,5 +105,5 @@ const processMarkdown = (markdown: string, imagesPath: string, indexJSON: Markdo
 export const getMarkdownContentAsHtml = async function(mdFilePath: string, imagesFilePath: string) {
   const markdown = await readMarkdownFile(mdFilePath, imagesFilePath);
   const content = matter(markdown).content;
-  return mdToHtml(content).html;
+  return mdToHtml(content, false, '1', imagesFilePath).html;
 }


### PR DESCRIPTION
move img tag manipulation to be handled by marked's custom renderer