### PR TITLE
add link to section - button for documentation headers

### DIFF
--- a/lib/customMarked.test.ts
+++ b/lib/customMarked.test.ts
@@ -1,15 +1,19 @@
 import slugify from 'slugify'
 import { BADGE_TEMPLATES, mdToHtml } from './customMarked'
 
+
+const BUTTON_START = `<button title="Link to section" class="updateHrefButton" onclick="window.location.hash = '`;
+const BUTTON_END =  `'"><i class="fa-regular fa-link"></i></button>`;
 const createTestMd = () => {
   const originals = []
   const expecteds = []
-  for (let first = 1; first < 4; first++) {
+  for (let first = 1; first < 3; first++) {
     originals.push('# ' + first + '\r\n')
     expecteds.push(
-      '<h1 id="' + first + '">' + first + ' ' + first + '</h1>\r\n'
+      '<h1 id="' + first + '">' + first + ' ' + first + BUTTON_START + first + BUTTON_END + '</h1>\r\n'.trim()
     )
-    for (let second = 1; second < 4; second++) {
+
+    for (let second = 1; second < 3; second++) {
       const joinedSecond = [first, second].join('.')
       originals.push('## ' + joinedSecond + '\r\n')
       expecteds.push(
@@ -19,9 +23,10 @@ const createTestMd = () => {
           joinedSecond +
           ' ' +
           joinedSecond +
+          BUTTON_START + joinedSecond + BUTTON_END +
           '</h2>\r\n'
       )
-      for (let third = 1; third < 4; third++) {
+      for (let third = 1; third < 3; third++) {
         const joinedThird = [first, second, third].join('.')
         originals.push('### ' + joinedThird + '\r\n')
         expecteds.push(
@@ -31,6 +36,7 @@ const createTestMd = () => {
             joinedThird +
             ' ' +
             joinedThird +
+            BUTTON_START + joinedThird + BUTTON_END +
             '</h3>\r\n'
         )
       }
@@ -41,6 +47,10 @@ const createTestMd = () => {
     originals,
     expecteds,
   }
+}
+
+const  normalizeHtml = (html: string) => {
+  return html.replace(/\s+/g, "").trim();
 }
 
 describe('mdToHTML tests', () => {
@@ -61,14 +71,14 @@ describe('mdToHTML tests', () => {
     it("should handle headings' semantic numbering", () => {
       const generated = createTestMd()
       // <div><h1>1</h1><h2>1.1</h2>.....
-      const originalMd = generated.originals.join('')
+      const originalMd = generated.originals.join('');
       // <div><h1 id="1">1 1</h1><h2 id="1.1">1.1 1.1</h2>....
-      const expectedHtml = generated.expecteds.join('')
+      const expectedHtml = generated.expecteds.join('');
 
       //      console.log(originalMd);
       //      console.log(expectedHtml);
-      const processedHTML = mdToHtml(originalMd, true, '1').html
-      expect(processedHTML).toEqual(expectedHtml)
+      const processedHTML = mdToHtml(originalMd, true, '1').html.trim()
+      expect(normalizeHtml(processedHTML)).toEqual(normalizeHtml(expectedHtml));
     })
 
     it('should NOT allow zeros in semantic numbering (case skipping heading levels)', () => {

--- a/lib/customMarked.ts
+++ b/lib/customMarked.ts
@@ -17,6 +17,7 @@ export const BADGE_TEMPLATES: {[key: string]: string} = {
     '[breaking]': '<span class="label label-primary breaking" title="Breaking change. Not backwards compatible."><i class="fa-solid fa-triangle-exclamation"></i></span>',
     '[rpc]': '<span class="label label-primary rpc" title="Available via RPC">RPC</span>',
 };
+const HREF_BUTTON_TITLE = "Link to section";
 
 const createRenderer = (useSectionNumbering: boolean, startingSectionNumber: string, anchorLinks: Array<DocAnchorLinksType>) => {
     const renderer = new marked.Renderer();
@@ -44,26 +45,36 @@ const createRenderer = (useSectionNumbering: boolean, startingSectionNumber: str
         previousLevel = intLevel;
 
         const tags = content.match(tagRegex);
-        let cleanTitle = content.replace(tagRegex, '').trim();
+        let titleText = content.replace(tagRegex, '').trim();
 
-        const slug = slugify(cleanTitle)
+        const slug = slugify(titleText)
         const sectionNumber = sectionCounter.slice(0, level).map(sectionNumber => sectionNumber || 1).join('.');
 
         const sectionNumberContent = useSectionNumbering ? sectionNumber + ' ' : '';
         anchorLinks.push({ level: level.toString(), content, slug, sectionNumber });
 
+        let badges: (string | null)[] = [];
         if (tags && tags.length > 0) {
-          const badges = tags.map((tag: string) => {
+          badges = tags.map((tag: string) => {
             if (!!BADGE_TEMPLATES[tag.toLowerCase()]) {
               return BADGE_TEMPLATES[tag.toLowerCase()];
             }
             return null;
           }).filter((badge: string | null) => !!badge);
-
-          cleanTitle = `<h${level} id="${slug}">${sectionNumberContent}${cleanTitle}${badges.join(' ')}</h${level}>`;
-        } else {
-          cleanTitle = `<h${level} id="${slug}">${sectionNumberContent}${cleanTitle}</h${level}>`;
         }
+
+        let cleanTitle = `<h${level} id="${slug}">`;
+        cleanTitle += `${sectionNumberContent}${titleText}${badges?.join(' ') || ''}`;
+
+        // when there are numbered headings (case documentation) additional link-button is added
+        if (useSectionNumbering) {
+          cleanTitle +=
+            `<button title="${HREF_BUTTON_TITLE}" class="updateHrefButton" onclick="window.location.hash = '${slug}'">
+              <i class="fa-regular fa-link"></i>
+            </button>`;
+        }
+
+        cleanTitle += `</h${level}>`;
 
         // additional \r\n needs to be added cos marked is failing in a load of ways,
         // when the first element after heading is a link or a list or whatnot and this is missing in source.

--- a/lib/customMarked.ts
+++ b/lib/customMarked.ts
@@ -45,7 +45,7 @@ const createRenderer = (useSectionNumbering: boolean, startingSectionNumber: str
         previousLevel = intLevel;
 
         const tags = content.match(tagRegex);
-        let titleText = content.replace(tagRegex, '').trim();
+        const titleText = content.replace(tagRegex, '').trim();
 
         const slug = slugify(titleText)
         const sectionNumber = sectionCounter.slice(0, level).map(sectionNumber => sectionNumber || 1).join('.');

--- a/styles/apidoc.scss
+++ b/styles/apidoc.scss
@@ -31,6 +31,16 @@ div.apidocContentWrapper {
   th {
     text-align: left;
   }
+
+  .updateHrefButton {
+    float: right;
+    font-size: 1.2rem;
+
+    &:hover {
+      cursor: pointer
+    }
+  }
+
 }
 
 .apidocSidebarLink {
@@ -55,52 +65,52 @@ div.apidocContentWrapper {
 }
 
 
-  /*badges*/
-  span.label.label-primary {
-    margin-left: 4px;
-    margin-right: 4px;
+/*badges*/
+span.label.label-primary {
+  margin-left: 4px;
+  margin-right: 4px;
 
-    &.add {
-      background-color : green;
-    }
-
-    &.mod {
-      background-color : orange;
-    }
-
-    &.rem {
-      background-color : red;
-    }
-
-    &.breaking {
-      background-color : red;
-    }
-
+  &.add {
+    background-color : green;
   }
 
-  .label-primary {
-    background-color: #428bca;
+  &.mod {
+    background-color : orange;
   }
 
-  .label {
-    display: inline;
-    padding: .4em .6em .2em .6em;
-    font-size: 75%;
-    font-weight: 700;
-    line-height: 1;
-    color: #fff;
-    text-align: center;
-    white-space: nowrap;
-    vertical-align: baseline;
-    border-radius: .25em;
+  &.rem {
+    background-color : red;
   }
 
-  code:not(.hljs) {
-    padding: 2px 4px;
-    font-size: 90%;
-    color: #c7254e;
-    background-color: #f9f2f4;
-    border-radius: 4px;
-    overflow: hidden;
-    word-wrap: break-word;
+  &.breaking {
+    background-color : red;
   }
+
+}
+
+.label-primary {
+  background-color: #428bca;
+}
+
+.label {
+  display: inline;
+  padding: .4em .6em .2em .6em;
+  font-size: 75%;
+  font-weight: 700;
+  line-height: 1;
+  color: #fff;
+  text-align: center;
+  white-space: nowrap;
+  vertical-align: baseline;
+  border-radius: .25em;
+}
+
+code:not(.hljs) {
+  padding: 2px 4px;
+  font-size: 90%;
+  color: #c7254e;
+  background-color: #f9f2f4;
+  border-radius: 4px;
+  overflow: hidden;
+  word-wrap: break-word;
+}


### PR DESCRIPTION
Added a button to save the link to a given heading in documentation section. The button updates the address bar with the hash of the section. This should help make it easier to link to correct part of documentation. 

<img width="1191" height="422" alt="image" src="https://github.com/user-attachments/assets/1e474233-cb91-4499-9ebd-0be7efa91994" />
