### PR TITLE
Og meta tags

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -8,6 +8,7 @@ import Link from 'next/link'
 import { ArrowLeftIcon } from '@heroicons/react/20/solid'
 import Image from 'next/image'
 import { getMarkdownContentAsHtml } from '@/lib/utils';
+import { Metadata } from 'next';
 
 const getPostBySlug = (slug: string) => {
     const found = allPosts.find((entry) => {
@@ -15,6 +16,39 @@ const getPostBySlug = (slug: string) => {
     });
 
     return found;
+}
+
+export const generateMetadata = async ({
+    params,
+}: {
+    params: Promise<{ slug: string }>
+}): Promise<Metadata> => {
+    const { slug } = await params;
+    const post = getPostBySlug(slug);
+
+    if (!post) {
+        return {
+            title: 'Blog',
+        };
+    }
+
+    const postImage = post.image || (post.imagesFromPost?.[0] ?? undefined);
+
+    return {
+        title: post.title,
+        description: post.excerpt,
+        openGraph: {
+            title: post.title,
+            description: post.excerpt,
+            images: postImage ? [{ url: postImage, alt: post.title }] : undefined,
+            type: 'article',
+        },
+        twitter: {
+            title: post.title,
+            description: post.excerpt,
+            images: postImage ? [postImage] : undefined,
+        },
+    };
 }
 
 export default async function SingleBlogPage({

--- a/app/blog/layout.tsx
+++ b/app/blog/layout.tsx
@@ -1,0 +1,13 @@
+import { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Blog',
+}
+
+export default function BlogLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return children
+}

--- a/app/discover/functionalities/page.tsx
+++ b/app/discover/functionalities/page.tsx
@@ -10,7 +10,7 @@ import { DISCOVER_FUNCTIONALITIES } from '@/utils/data/whychooseoskari'
 import { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: 'Discover',
+  title: 'Functionalities',
 }
 
 export default function DiscoverPage() {

--- a/app/documentation/api/bundles/layout.tsx
+++ b/app/documentation/api/bundles/layout.tsx
@@ -1,6 +1,17 @@
 import DefaultLayout from '@/components/Layout'
+import type { Metadata } from 'next'
 import { Suspense } from 'react'
 import Loading from '../../docs/loading'
+
+export const metadata: Metadata = {
+  title: 'API Bundles',
+  openGraph: {
+    title: 'API Bundles',
+  },
+  twitter: {
+    title: 'API Bundles',
+  },
+}
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (

--- a/app/documentation/api/events/layout.tsx
+++ b/app/documentation/api/events/layout.tsx
@@ -1,6 +1,17 @@
 import DefaultLayout from '@/components/Layout'
+import type { Metadata } from 'next'
 import { Suspense } from 'react'
 import Loading from '../../docs/loading'
+
+export const metadata: Metadata = {
+  title: 'API Events',
+  openGraph: {
+    title: 'API Events',
+  },
+  twitter: {
+    title: 'API Events',
+  },
+}
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (

--- a/app/documentation/api/page.tsx
+++ b/app/documentation/api/page.tsx
@@ -2,6 +2,17 @@ import Button from "@/components/Button";
 import HighlightBox from "@/components/HighlightBox";
 import DefaultLayout from "@/components/Layout";
 import Text from '@/components/Text'
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Oskari API',
+  openGraph: {
+    title: 'Oskari API',
+  },
+  twitter: {
+    title: 'Oskari API',
+  },
+}
 
 export default function ApiMainPage() {
   return <DefaultLayout heroSmall heroTitle="Oskari API">

--- a/app/documentation/api/requests/layout.tsx
+++ b/app/documentation/api/requests/layout.tsx
@@ -1,6 +1,17 @@
 import DefaultLayout from '@/components/Layout'
+import type { Metadata } from 'next'
 import { Suspense } from 'react'
 import Loading from '../../docs/loading'
+
+export const metadata: Metadata = {
+  title: 'API Requests',
+  openGraph: {
+    title: 'API Requests',
+  },
+  twitter: {
+    title: 'API Requests',
+  },
+}
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (

--- a/app/documentation/docs/[version]/[slug]/page.tsx
+++ b/app/documentation/docs/[version]/[slug]/page.tsx
@@ -5,6 +5,7 @@ import {  getVersionIndex } from '@/lib/utils'
 import availableVersions from '@/_content/docs';
 import Error from '@/components/Error'
 import { MarkdownFileMetadata } from '@/types/types'
+import type { Metadata } from 'next'
 import '@/styles/apidoc.scss'
 import '@fortawesome/fontawesome-free/js/fontawesome.min.js';
 import '@fortawesome/fontawesome-free/css/fontawesome.min.css';
@@ -18,15 +19,26 @@ export const generateMetadata = async ({
   params,
 }: {
   params: Promise<{ version: string, slug: string }>
-}) => {
+}): Promise<Metadata> => {
   const { version, slug } = await params;
   await initIndexJSON(version)
   const section = indexJSON[version]?.find((item: MarkdownFileMetadata) => item.slug === slug);
 
   if (section) {
-    return { title: section.title }
+    return {
+      title: section.title,
+      openGraph: {
+        title: section.title,
+      },
+      twitter: {
+        title: section.title,
+      },
+    }
   }
 
+  return {
+    title: 'Documentation',
+  }
 }
 
 const initIndexJSON = async (version: string) => {

--- a/app/documentation/docs/layout.tsx
+++ b/app/documentation/docs/layout.tsx
@@ -1,6 +1,17 @@
 import DefaultLayout from '@/components/Layout'
+import type { Metadata } from 'next'
 import { Suspense } from 'react'
 import Loading from './loading'
+
+export const metadata: Metadata = {
+  title: 'Documentation',
+  openGraph: {
+    title: 'Documentation',
+  },
+  twitter: {
+    title: 'Documentation',
+  },
+}
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,13 +2,34 @@ import '../styles/main.scss'
 import type { Metadata } from 'next'
 import { leagueSpartan, mavenPro } from '@/utils/fonts'
 
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://oskari.org'
+const ogImage = '/assets/images/oskari_logo_black_horizontal.png'
+
 export const metadata: Metadata = {
+  metadataBase: new URL(siteUrl),
   title: {
     template: '%s - Oskari Map Application Platform',
     default: 'Oskari Map Application Platform',
   },
   description:
     'Oskari is a framework for easily building multipurpose web mapping applications utilizing distributed Spatial Data Infrastructures like INSPIRE.',
+  openGraph: {
+    type: 'website',
+    url: siteUrl,
+    siteName: 'Oskari Map Application Platform',
+    description:
+      'Oskari is a framework for easily building multipurpose web mapping applications utilizing distributed Spatial Data Infrastructures like INSPIRE.',
+    images: [
+      {
+        url: ogImage,
+        alt: 'Oskari Map Application Platform',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    images: [ogImage],
+  },
 }
 
 export default function RootLayout({


### PR DESCRIPTION
improved social media pastability capabilites by adding og: etc meta tags. Can't really test these locally, other than to check they exist in source. Anyway, the title should live according to the section we're in and it should be sniffing for the main image of blog postings etc. 

<img width="1290" height="287" alt="image" src="https://github.com/user-attachments/assets/9ea371f3-de48-48e1-b03b-6b4b7861e789" />

<img width="781" height="230" alt="image" src="https://github.com/user-attachments/assets/61bbf306-cb3f-409a-9957-525ef0f7cf5d" />
